### PR TITLE
Allow pull to refresh for bikes

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/data/server/RetrofitClient.java
+++ b/app/src/main/java/it/geosolutions/savemybike/data/server/RetrofitClient.java
@@ -44,7 +44,7 @@ public class RetrofitClient {
 
     private Retrofit retrofit;
     private Retrofit portalRetrofit;
-    private OkHttpClient client;
+
     private OkHttpClient portalClient;
 
     private Context context;
@@ -140,17 +140,20 @@ public class RetrofitClient {
     private void fetchBikes(@NonNull final GetBikesCallback callback){
 
         //do the (retrofit) get call
-        final Call<PaginatedResult<Bike>> call = getPortalServices().getMyBikes();
+        getPortalServices().getMyBikes().enqueue(new Callback<PaginatedResult<Bike>>() {
+            @Override
+            public void onResponse(Call<PaginatedResult<Bike>> call, retrofit2.Response<PaginatedResult<Bike>> response) {
+                final PaginatedResult<Bike> bikesList = response.body();
+                callback.gotBikes(bikesList);
+            }
 
-        try {
-            final PaginatedResult<Bike> bikesList = call.execute().body();
+            @Override
+            public void onFailure(Call<PaginatedResult<Bike>> call, Throwable t) {
+                callback.error("io-error executing fetchBikes");
+            }
+        });
 
-            callback.gotBikes(bikesList);
 
-        } catch (IOException e) {
-            Log.e(TAG, "error executing fetchBikes", e);
-            callback.error("io-error executing fetchBikes");
-        }
     }
 
     private Retrofit getRetrofit(){

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/BikeListFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/BikeListFragment.java
@@ -166,6 +166,13 @@ public class BikeListFragment extends Fragment {
         }).execute();
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        refreshLayout.setRefreshing(true);
+        getBikes();
+    }
+
     public void showLoading(boolean show) {
         refreshLayout.setRefreshing(show);
         // loading.setVisibility(show ? View.VISIBLE : View.GONE);

--- a/app/src/main/res/layout/fragment_bikes.xml
+++ b/app/src/main/res/layout/fragment_bikes.xml
@@ -7,11 +7,32 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <include layout="@layout/empty_bikes" android:id="@+id/empty_bikes"/>
-    <ListView
-        android:id="@+id/bikes_list"
+    <LinearLayout
+        android:id="@+id/progress_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:listitem="@layout/item_bike"/>
+        android:layout_height="match_parent"
+        android:gravity="center_horizontal|center_vertical"
+        android:orientation="vertical"
+        android:visibility="gone"
+        >
+
+        <ProgressBar
+            style="?android:attr/progressBarStyleLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <android.support.v4.widget.SwipeRefreshLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/swiperefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <ListView
+            android:id="@+id/bikes_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:listitem="@layout/item_bike"/>
+    </android.support.v4.widget.SwipeRefreshLayout>
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/add_bike_button"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_bikes.xml
+++ b/app/src/main/res/layout/fragment_bikes.xml
@@ -7,20 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <include layout="@layout/empty_bikes" android:id="@+id/empty_bikes"/>
-    <LinearLayout
-        android:id="@+id/progress_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center_horizontal|center_vertical"
-        android:orientation="vertical"
-        android:visibility="gone"
-        >
-
-        <ProgressBar
-            style="?android:attr/progressBarStyleLarge"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-    </LinearLayout>
+    <include layout="@layout/loading_container" android:id="@+id/bike_status_loading" />
 
     <android.support.v4.widget.SwipeRefreshLayout
         xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -166,4 +166,5 @@
     <string name="confirm">Confermo</string>
     <string name="error_saving_bike_status">C\'è stato un errore mentre si tentava di salvare lo stato della bici. Ritentare più tardi</string>
     <string name="confirm_bike_found">Confermi di aver ritrovato questa bici?</string>
+    <string name="network_error">Errore di rete. Riprovare più tardi</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,5 +198,6 @@
     <string name="confirm">Confirm</string>
     <string name="error_saving_bike_status">There was an error trying to save the bike status. Please try again later</string>
     <string name="confirm_bike_found">Do you confirm you have found this bike?</string>
+    <string name="network_error">Network error. Please try again later</string>
 
 </resources>


### PR DESCRIPTION
Actually bikes can not be refreshed. This PR allow pull-to-refresh functionality for bikes in bike list (and also auto-refresh) when open the bikes view: 

When a user backs from "add" (actually it opens the browser to allow bikes add), the app  auto-refresh the list (as for every onResume event of the fragment). 