### PR TITLE
Fixed session close issue

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/data/service/SaveMyBikeService.java
+++ b/app/src/main/java/it/geosolutions/savemybike/data/service/SaveMyBikeService.java
@@ -63,6 +63,7 @@ public class SaveMyBikeService extends Service {
         if(BuildConfig.DEBUG) {
             Log.d(TAG, "onCreate");
         }
+
     }
 
     @Override
@@ -132,8 +133,10 @@ public class SaveMyBikeService extends Service {
         }
 
         //6.finally, show a notification
-        getNotificationManager().startNotification(getResources().getString(R.string.state_started), vehicle);
 
+
+
+        startForeground(1,  getNotificationManager().startNotification(getResources().getString(R.string.state_started), vehicle));
         return START_STICKY;
     }
 

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
@@ -159,9 +159,9 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
 
         if(session != null){
 
-            if(statsHidden){
+            if(statsRow != null){
+                // this refrence could be null due to close the application
                 statsRow.setVisibility(View.VISIBLE);
-                statsHidden = false;
             }
 
             final double dist = session.getDistance();
@@ -177,13 +177,7 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
             timeTV.setText(Util.longToTimeString(time));
 
         }
-        /*
-        else{
-            if(!statsHidden){
-                statsRow.setVisibility(View.INVISIBLE);
-                statsHidden = true;
-            }
-        }*/
+
     }
 
     /**


### PR DESCRIPTION
Due to current management of background services, the application risks to be killed by the OS after during background recording process. 

This fix makes the service run in foreground so the process will no be killed anymore. 

In addition, I had to add some checks to avoid application crash when the user clicks on the notification but the application is really closed. 