### PR TITLE
Prompt the retry button when could not check user data

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/LoginActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/LoginActivity.java
@@ -273,15 +273,17 @@ public final class LoginActivity extends AppCompatActivity {
                         @Override
                         public void onResponse(Call<UserInfo> call, Response<UserInfo> response) {
                             User user = response.body();
-                            if(user == null // first login
+                            if(response.code() == 200 && (user == null // first login
                                     || user.getAcceptedTermsOfService() == null // old users that didn't have the profile autocomplete but did login
-                                    || user.getAcceptedTermsOfService() == false )
+                                    || user.getAcceptedTermsOfService() == false) )
                                 {
                                     Intent intent = new Intent(context, CompleteProfile.class);
                                     intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                                     startActivity(intent);
                                     finish();
-                                } else {
+                                } else if (response.code() >= 500 || response.code() == 404 ){
+                                displayError(getResources().getString(R.string.could_not_verify_user), true);
+                            }else {
                                     Intent intent = new Intent(context, SaveMyBikeActivity.class);
                                     intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                                     startActivity(intent);
@@ -292,7 +294,7 @@ public final class LoginActivity extends AppCompatActivity {
 
                         @Override
                         public void onFailure(Call<UserInfo> call, Throwable t) {
-                            displayNotAuthorized(getResources().getString(R.string.could_not_verify_user));
+                            displayError(getResources().getString(R.string.could_not_verify_user), true);
                         }
                     });
 


### PR DESCRIPTION
Actually the application can work offline, but first login and profile registration need the internet connection. 
When the user does the login for the first time, if the server is not available, but keycloack is available, the user's profile completition status can not be loaded, even if the user is able to login.

This causes an error that brings the user to the profile completion wizard. 

This PR shows instead an error ("couldn't check user's data. Please try again later", with a retry button)