### PR TITLE
Fix #49 Display validity of tracks

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/data/server/SMBRemoteServices.java
+++ b/app/src/main/java/it/geosolutions/savemybike/data/server/SMBRemoteServices.java
@@ -45,9 +45,6 @@ public interface SMBRemoteServices {
     );
 
     @GET("api/my-tracks/?format=json")
-    Call <PaginatedResult<Track>> getTracks(@Query("page") int page);
-
-    @GET("api/my-tracks/?format=json")
     Call<PaginatedResult<TrackItem>> getTracks();
 
     @GET("api/my-tracks/{id}?format=json")

--- a/app/src/main/java/it/geosolutions/savemybike/model/TrackItem.java
+++ b/app/src/main/java/it/geosolutions/savemybike/model/TrackItem.java
@@ -19,6 +19,10 @@ public class TrackItem extends BaseTrack {
 
     private HealthData health;
 
+    @SerializedName("is_valid") private boolean isValid;
+
+    @SerializedName("validation_error") private boolean validationError;
+
     public ArrayList<Segment> getSegments() {
         return segments;
     }
@@ -52,8 +56,19 @@ public class TrackItem extends BaseTrack {
     }
 
 
-    public boolean isInvalid() {
-        return true;
+    public boolean isValid() {
+        return isValid;
     }
 
+    public void setValid(boolean valid) {
+        isValid = valid;
+    }
+
+    public boolean isValidationError() {
+        return validationError;
+    }
+
+    public void setValidationError(boolean validationError) {
+        this.validationError = validationError;
+    }
 }

--- a/app/src/main/java/it/geosolutions/savemybike/model/TrackItem.java
+++ b/app/src/main/java/it/geosolutions/savemybike/model/TrackItem.java
@@ -51,4 +51,9 @@ public class TrackItem extends BaseTrack {
         this.health = health;
     }
 
+
+    public boolean isInvalid() {
+        return true;
+    }
+
 }

--- a/app/src/main/java/it/geosolutions/savemybike/model/TrackItem.java
+++ b/app/src/main/java/it/geosolutions/savemybike/model/TrackItem.java
@@ -21,7 +21,7 @@ public class TrackItem extends BaseTrack {
 
     @SerializedName("is_valid") private boolean isValid;
 
-    @SerializedName("validation_error") private boolean validationError;
+    @SerializedName("validation_error") private String validationError;
 
     public ArrayList<Segment> getSegments() {
         return segments;
@@ -64,11 +64,11 @@ public class TrackItem extends BaseTrack {
         isValid = valid;
     }
 
-    public boolean isValidationError() {
+    public String getValidationError() {
         return validationError;
     }
 
-    public void setValidationError(boolean validationError) {
+    public void setValidationError(String validationError) {
         this.validationError = validationError;
     }
 }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/adapters/SessionAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/adapters/SessionAdapter.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.ImageView;
 import android.widget.ListAdapter;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -81,9 +82,12 @@ public abstract class SessionAdapter extends ArrayAdapter<Session> {
             durationTV.setText(DateTimeFormat.forPattern("HH:mm:ss").print(date.plus(duration)));
             view.setTag(session.getId());
             if(session.isUploaded()) {
-                view.findViewById(R.id.uploaded).setVisibility(View.VISIBLE);
+                ImageView iv = view.findViewById(R.id.status);
+                iv.setVisibility(View.VISIBLE);
+                iv.setImageResource(R.drawable.ic_circle_checked);
+                iv.setColorFilter(getContext().getResources().getColor(R.color.green));
             } else {
-                view.findViewById(R.id.uploaded).setVisibility(View.GONE);
+                view.findViewById(R.id.status).setVisibility(View.GONE);
             }
         }
 

--- a/app/src/main/java/it/geosolutions/savemybike/ui/adapters/TrackItemAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/adapters/TrackItemAdapter.java
@@ -37,6 +37,9 @@ public class TrackItemAdapter extends ArrayAdapter<TrackItem> {
     private	int resource;
     static class ViewHolder {
         @BindView(R.id.status) ImageView status;
+        @BindView(R.id.km_view) TextView kmView;
+        @BindView(R.id.dist_value) TextView distValue;
+        @BindView(R.id.invalid_message) TextView invalidMessage;
         public ViewHolder(View view) {
             ButterKnife.bind(this, view);
         }
@@ -76,10 +79,16 @@ public class TrackItemAdapter extends ArrayAdapter<TrackItem> {
             TrackDetailsActivity.inflateTrackDataToRecordView(track, view);
             if(track.isValid()) {
                 holder.status.setVisibility(View.GONE);
+                holder.kmView.setVisibility(View.VISIBLE);
+                holder.distValue.setVisibility(View.VISIBLE);
+                holder.invalidMessage.setVisibility(View.GONE);
             } else {
                 holder.status.setVisibility(View.VISIBLE);
                 holder.status.setImageResource(R.drawable.ic_error);
                 holder.status.setColorFilter(getContext().getResources().getColor(R.color.red));
+                holder.kmView.setVisibility(View.GONE);
+                holder.distValue.setVisibility(View.GONE);
+                holder.invalidMessage.setVisibility(View.VISIBLE);
             }
         }
 

--- a/app/src/main/java/it/geosolutions/savemybike/ui/adapters/TrackItemAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/adapters/TrackItemAdapter.java
@@ -3,10 +3,12 @@ package it.geosolutions.savemybike.ui.adapters;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.constraint.ConstraintLayout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -18,6 +20,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+import butterknife.BindView;
+import butterknife.ButterKnife;
 import it.geosolutions.savemybike.R;
 import it.geosolutions.savemybike.model.Segment;
 import it.geosolutions.savemybike.model.Track;
@@ -31,6 +35,13 @@ import it.geosolutions.savemybike.ui.activity.TrackDetailsActivity;
 public class TrackItemAdapter extends ArrayAdapter<TrackItem> {
 
     private	int resource;
+    static class ViewHolder {
+        @BindView(R.id.status) ImageView status;
+        public ViewHolder(View view) {
+            ButterKnife.bind(this, view);
+        }
+    }
+
 
     public TrackItemAdapter(final Context context, int textViewResourceId, List<TrackItem> sessions){
         super(context, textViewResourceId, sessions);
@@ -41,23 +52,35 @@ public class TrackItemAdapter extends ArrayAdapter<TrackItem> {
     @NonNull
     @Override
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
-
-        RelativeLayout view;
-
+        TrackItemAdapter.ViewHolder holder;
+        ConstraintLayout view;
+        if (convertView != null) {
+            holder = (TrackItemAdapter.ViewHolder) convertView.getTag();
+        } else {
+            LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            convertView = inflater.inflate(resource, parent, false);
+            holder = new TrackItemAdapter.ViewHolder(convertView);
+            convertView.setTag(holder);
+        }
         if(convertView == null){
-            view = new RelativeLayout(getContext());
+            view = new ConstraintLayout(getContext());
 
             LayoutInflater li = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             li.inflate(resource, view,true);
         }else{
-            view = (RelativeLayout) convertView;
+            view = (ConstraintLayout) convertView;
         }
 
         final TrackItem track = getItem(position);
         if(track != null) {
-
             TrackDetailsActivity.inflateTrackDataToRecordView(track, view);
-            view.setTag(track.getId());
+            if(track.isInvalid()) {
+                holder.status.setVisibility(View.VISIBLE);
+                holder.status.setImageResource(R.drawable.ic_error);
+                holder.status.setColorFilter(getContext().getResources().getColor(R.color.red));
+            } else {
+                holder.status.setVisibility(View.GONE);
+            }
         }
 
         return view;

--- a/app/src/main/java/it/geosolutions/savemybike/ui/adapters/TrackItemAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/adapters/TrackItemAdapter.java
@@ -74,12 +74,12 @@ public class TrackItemAdapter extends ArrayAdapter<TrackItem> {
         final TrackItem track = getItem(position);
         if(track != null) {
             TrackDetailsActivity.inflateTrackDataToRecordView(track, view);
-            if(track.isInvalid()) {
+            if(track.isValid()) {
+                holder.status.setVisibility(View.GONE);
+            } else {
                 holder.status.setVisibility(View.VISIBLE);
                 holder.status.setImageResource(R.drawable.ic_error);
                 holder.status.setColorFilter(getContext().getResources().getColor(R.color.red));
-            } else {
-                holder.status.setVisibility(View.GONE);
             }
         }
 

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
@@ -80,9 +80,9 @@ public class TracksFragment extends Fragment {
                 getActivity().overridePendingTransition(R.anim.fadein, R.anim.fadeout);
             } else {
                 if(t.getValidationError() != null) {
-                    // TODO: validation error
+                    Toast.makeText(getContext(), R.string.track_invalid_message, Toast.LENGTH_LONG).show();
                 } else {
-                    Toast.makeText(getContext(), R.string.track_invalid, Toast.LENGTH_LONG).show();
+                    Toast.makeText(getContext(), R.string.track_invalid_message, Toast.LENGTH_LONG).show();
                 }
 
             }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
@@ -7,12 +7,12 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.ListView;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 
@@ -22,7 +22,6 @@ import it.geosolutions.savemybike.R;
 import it.geosolutions.savemybike.data.server.RetrofitClient;
 import it.geosolutions.savemybike.data.server.SMBRemoteServices;
 import it.geosolutions.savemybike.model.PaginatedResult;
-import it.geosolutions.savemybike.model.Track;
 import it.geosolutions.savemybike.model.TrackItem;
 import it.geosolutions.savemybike.ui.activity.TrackDetailsActivity;
 import it.geosolutions.savemybike.ui.adapters.TrackItemAdapter;
@@ -61,13 +60,12 @@ public class TracksFragment extends Fragment {
 
         mySwipeRefreshLayout.setOnRefreshListener(() -> getTracks());
         listView.setOnItemClickListener((parent, itemView, position, id) -> {
-
-
-            Intent intent = new Intent(getActivity(), TrackDetailsActivity.class);
             TrackItem t = (TrackItem) listView.getAdapter().getItem(position);
-            intent.putExtra(TrackDetailsActivity.TRACK_ID, t.getId());
+            if(t.isValid()) {
+                Intent intent = new Intent(getActivity(), TrackDetailsActivity.class);
 
-            /* TODO: animation transition. Something like this...
+                intent.putExtra(TrackDetailsActivity.TRACK_ID, t.getId());
+                /* TODO: animation transition. Something like this...
             // Check if we're running on Android 5.0 or higher
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 // create the transition animation - the images in the layouts
@@ -78,8 +76,20 @@ public class TracksFragment extends Fragment {
             } else {
                 getActivity().startActivity(intent);
             }*/
-            getActivity().startActivity(intent);
-            getActivity().overridePendingTransition(R.anim.fadein, R.anim.fadeout);
+                getActivity().startActivity(intent);
+                getActivity().overridePendingTransition(R.anim.fadein, R.anim.fadeout);
+            } else {
+                if(t.getValidationError() != null) {
+                    // TODO: validation error
+                } else {
+                    Toast.makeText(getContext(), R.string.track_invalid, Toast.LENGTH_LONG).show();
+                }
+
+            }
+
+
+
+
         });
         // TODO: show also sessions, grayed out
         getTracks();

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
@@ -22,6 +22,7 @@ import it.geosolutions.savemybike.R;
 import it.geosolutions.savemybike.data.server.RetrofitClient;
 import it.geosolutions.savemybike.data.server.SMBRemoteServices;
 import it.geosolutions.savemybike.model.PaginatedResult;
+import it.geosolutions.savemybike.model.Track;
 import it.geosolutions.savemybike.model.TrackItem;
 import it.geosolutions.savemybike.ui.activity.TrackDetailsActivity;
 import it.geosolutions.savemybike.ui.adapters.TrackItemAdapter;
@@ -63,8 +64,8 @@ public class TracksFragment extends Fragment {
 
 
             Intent intent = new Intent(getActivity(), TrackDetailsActivity.class);
-
-            intent.putExtra(TrackDetailsActivity.TRACK_ID, (Long) itemView.getTag());
+            TrackItem t = (TrackItem) listView.getAdapter().getItem(position);
+            intent.putExtra(TrackDetailsActivity.TRACK_ID, t.getId());
 
             /* TODO: animation transition. Something like this...
             // Check if we're running on Android 5.0 or higher

--- a/app/src/main/res/drawable/circle_green.xml
+++ b/app/src/main/res/drawable/circle_green.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape android:shape="oval" xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/green"/>
+    <solid android:color="@color/caribbean_green"/>
 </shape>

--- a/app/src/main/res/drawable/ic_error.xml
+++ b/app/src/main/res/drawable/ic_error.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>
+</vector>

--- a/app/src/main/res/layout/item_track.xml
+++ b/app/src/main/res/layout/item_track.xml
@@ -146,5 +146,20 @@
         tools:src="@drawable/ic_error"
         tools:visibility="visible" />
 
+    <TextView
+        android:id="@+id/invalid_message"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/track_invalid_message_short"
+        app:layout_constraintBottom_toBottomOf="@+id/session_type_icon"
+        app:layout_constraintEnd_toEndOf="@+id/imageView"
+        app:layout_constraintStart_toEndOf="@+id/session_type_icon"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
+
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/item_track.xml
+++ b/app/src/main/res/layout/item_track.xml
@@ -59,24 +59,29 @@
 
     <LinearLayout
         android:id="@+id/vehicle_grid"
-        android:layout_width="97dp"
-        android:layout_height="37dp"
+        android:layout_width="72dp"
+        android:layout_height="36dp"
         android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="8dp"
         android:gravity="right"
+        android:orientation="horizontal"
         app:layout_constraintBottom_toTopOf="@+id/session_duration_text"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/imageView"
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
             android:id="@+id/vehicle_1"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            tools:src="@drawable/ic_directions_bike" />
 
         <ImageView
             android:id="@+id/vehicle_2"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            tools:src="@drawable/ic_directions_train" />
 
         <TextView
             android:id="@+id/more_veihicles"
@@ -130,19 +135,16 @@
         android:contentDescription="@string/session_duration" />
 
     <ImageView
-        android:id="@+id/uploaded"
-        android:visibility="gone"
+        android:id="@+id/status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
         android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintBottom_toTopOf="@+id/session_duration_text"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
         app:layout_constraintEnd_toStartOf="@+id/vehicle_grid"
-        app:layout_constraintStart_toEndOf="@+id/session_start_datetime"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_circle_checked" />
+        app:layout_constraintTop_toTopOf="@+id/vehicle_grid"
+        tools:src="@drawable/ic_error"
+        tools:visibility="visible" />
 
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -63,6 +63,8 @@
     <string name="no_network_description">Questa funzionalità non è disponibile offline. Provare di nuovo più tardi</string>
     <string name="no__track_title">Nessuna traccia disponibile</string>
     <string name="no_track_description">Non hai ancora nessuna traccia. Per creare una nuova traccia, registra il tuo percorso utlizzando la sezione \"Registra\". Alla fine della registrazione, apri il tab \"Da inviare\" nella sezione \"Statistiche\" ed invia i dati. Quando i dati saranno processati, vedrai la tua nuova traccia disponibile elencata qui</string>
+    <string name="track_invalid_message_short">Traccia non valida.</string>
+    <string name="track_invalid_message">La traccia selezionata non è risultata valida. Non verrà quindi conteggiata nei calcoli e nell\'assegnazione dei premi.</string>
     <string name="no_session_title">Nessuna registrazione da inviare</string>
     <string name="no_bikes_title">Nessuna Bici</string>
     <string name="server_took_too_long_to_respond" >Il server ha impiegato troppo tempo a rispondere</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,7 +20,9 @@
     <color name="lightgray">#ededed</color>
     <color name="deeppurple">#7c4dff</color>
     <color name="yellow">#ffb300</color>
-    <color name="green">#00bfa5</color>
+    <color name="caribbean_green">#00bfa5</color>
+    <color name="green">#087b00</color>
     <color name="darkblue">#152b38</color>
     <color name="pink">#fe104d</color>
+    <color name="red">#ff0000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,8 @@
     <string name="no_session_description">There is no recording to send. If you want to create a new recording use the \"Record\" tab</string>
     <string name="no__track_title">No Track Available</string>
     <string name="no_track_description">You don\'t have any track recorded. To create track, record using the \"Record\" tab first. At the end of the recording session, open the \"To Send\" tab in the \"Stats\" section and upload your data. You will see your data here after data processing end.</string>
+    <string name="track_invalid_message_short">Invalid track.</string>
+    <string name="track_invalid_message">This track has been identified as invalid. It will not be used in indexes count and assigning prizes</string>
     <string name="no_session_title">No Recording</string>
     <string name="no_bikes_title">No bikes</string>
     <string name="server_took_too_long_to_respond">Server took to much to respond</string>


### PR DESCRIPTION
This improves track items view to display validity.
![image](https://user-images.githubusercontent.com/1279510/47365578-282d3280-d6dc-11e8-8059-b510b878ccfe.png)
Clicking on the track you will see a toast with a better description:
![image](https://user-images.githubusercontent.com/1279510/47365824-a7226b00-d6dc-11e8-8781-3c4abcf99a21.png)

Still not provide information about the error reason. For the moment this is not a recoverable situation, so the reason is not so useful. 