### PR TITLE
Fix #67 Require GPS to start recording

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
@@ -1,5 +1,14 @@
 package it.geosolutions.savemybike.ui.fragment;
 
+import android.Manifest;
+import android.app.Activity;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -8,6 +17,7 @@ import android.support.annotation.Nullable;
 import android.support.constraint.Group;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -39,6 +49,8 @@ import it.geosolutions.savemybike.ui.callback.RecordingEventListener;
 public class RecordFragment extends Fragment implements RecordingEventListener {
 
     private final static String TAG = "RecordFragment";
+    private static final int GPS_ENABLE_REQUEST = 789;
+    LocationManager mLocationManager;
 
     @BindViews({
             R.id.mode_foot,
@@ -57,6 +69,17 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
     @BindView(R.id.stats_group) Group statsRow;
 
     private boolean statsHidden = true;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mLocationManager = (LocationManager) getActivity().getSystemService(Activity.LOCATION_SERVICE);
+        if (ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+                && ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED)
+        {
+            return;
+        }
+    }
 
     /**
      * inflates the view of this fragment and initializes it
@@ -242,10 +265,14 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
 
             applySessionState(Session.SessionState.STOPPED);
         } else {
+            if(mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+                ((SaveMyBikeActivity)getActivity()).startRecording();
 
-            ((SaveMyBikeActivity)getActivity()).startRecording();
+                applySessionState(Session.SessionState.ACTIVE);
+            } else {
+                showGPSDiabledDialog();
+            }
 
-            applySessionState(Session.SessionState.ACTIVE);
         }
     }
 
@@ -264,4 +291,44 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
         simulateTV.setVisibility(simulate ? View.VISIBLE : View.INVISIBLE);
     }
 
+
+
+    /**
+     * If GPS is disabled, show this dialog
+     */
+    public void showGPSDiabledDialog() {
+        if(getActivity() != null) { // this can be triggered when the user stopped gps. and the application is not present. In this case the activity doesn't exist anymore.
+            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+            builder.setTitle(R.string.gps_disabled_title);
+            builder.setMessage(R.string.gps_disabled_description);
+            builder.setPositiveButton(R.string.gps_enable, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    startActivityForResult(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS), GPS_ENABLE_REQUEST);
+                }
+            });
+            builder.create().show();
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        if (requestCode == GPS_ENABLE_REQUEST)
+        {
+            if (mLocationManager == null)
+            {
+                mLocationManager = (LocationManager) getActivity().getSystemService(Activity.LOCATION_SERVICE);
+            }
+
+            if (!mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER))
+            {
+                showGPSDiabledDialog();
+            }
+        }
+        else
+        {
+            super.onActivityResult(requestCode, resultCode, data);
+        }
+    }
 }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
@@ -306,6 +306,12 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
                 public void onClick(DialogInterface dialog, int which) {
                     startActivityForResult(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS), GPS_ENABLE_REQUEST);
                 }
+            })
+            .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+
+                }
             });
             builder.create().show();
         }

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -300,4 +300,7 @@
     <string name="dont_show_this_again">Non mostrare più questo messaggio</string>
     <string name="authors">Realizzato da</string>
     <string name="links">Links</string>
+    <string name="gps_disabled_title">GPS Disabilitato</string>
+    <string name="gps_disabled_description">Il Gps è disabilitato. Per registrare è necessario abilitare il GPS sul tuo device</string>
+    <string name="gps_enable">Enable GPS</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -301,6 +301,6 @@
     <string name="authors">Realizzato da</string>
     <string name="links">Links</string>
     <string name="gps_disabled_title">GPS Disabilitato</string>
-    <string name="gps_disabled_description">Il Gps è disabilitato. Per registrare è necessario abilitare il GPS sul tuo device</string>
-    <string name="gps_enable">Enable GPS</string>
+    <string name="gps_disabled_description">Il Gps è disabilitato. Per registrare è necessario abilitare il GPS sul tuo dispositivo</string>
+    <string name="gps_enable">Abilita GPS</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -333,4 +333,7 @@
     <string name="dont_show_this_again">Don\'t show this message again</string>
     <string name="authors">Made by</string>
     <string name="links">Links</string>
+    <string name="gps_disabled_title">GPS Disabled</string>
+    <string name="gps_disabled_description">Gps is disabled, in order to use the application properly you need to enable GPS of your device</string>
+    <string name="gps_enable">Enable GPS</string>
 </resources>


### PR DESCRIPTION
If GPS is disabled, when user tries to start recording, he will see this prompt. 

Fix #67 


![image](https://user-images.githubusercontent.com/1279510/47578101-cf160680-d948-11e8-856f-a63a37d28fa1.png)


I tried to update notification if user or android disables GPS during the path, but it seems to be tricky. We can add this improvement to a future release, what do you thing @giohappy 