### PR TITLE
Fix #70. Hide to send section when uploading or recording

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/data/server/S3Manager.java
+++ b/app/src/main/java/it/geosolutions/savemybike/data/server/S3Manager.java
@@ -28,6 +28,7 @@ import it.geosolutions.savemybike.BuildConfig;
 import it.geosolutions.savemybike.data.Constants;
 import it.geosolutions.savemybike.data.Util;
 import it.geosolutions.savemybike.data.db.SMBDatabase;
+import it.geosolutions.savemybike.data.service.UserNotificationManager;
 import it.geosolutions.savemybike.model.Session;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -45,6 +46,7 @@ public class S3Manager implements TransferListener{
 
     private Context context;
     private boolean wifiOnly;
+    private static int uploadCount = 0;
 
     // The TransferUtility is the primary class for managing transfer to S3
 //    private TransferUtility transferUtility;
@@ -129,7 +131,7 @@ public class S3Manager implements TransferListener{
         //create CSV
         CSVCreator csvCreator = new CSVCreator();
         RetrofitClient retrofitClient = RetrofitClient.getInstance(context);
-
+        uploadCount = sessionsToUpload.size();
         for(Session session : sessionsToUpload){
 
             //String sessionFilePath = csvCreator.createCSV(session);
@@ -178,16 +180,21 @@ public class S3Manager implements TransferListener{
                             Log.v("Upload", "failed");
                             S3Manager.this.onStateChanged(dirtyHackWaitingForARefactor, TransferState.FAILED);
                         }
-
+                        uploadCount--;
                     }
 
                     @Override
                     public void onFailure(Call<ResponseBody> call, Throwable t) {
                         Log.e("Upload error:", t.getMessage());
                         S3Manager.this.onError(dirtyHackWaitingForARefactor, new Exception(t));
+                        uploadCount--;
                     }
                 });
         }
+    }
+
+    public static boolean isUploading() {
+        return uploadCount > 0;
     }
 
     @NonNull

--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/SaveMyBikeActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/SaveMyBikeActivity.java
@@ -510,8 +510,12 @@ public class SaveMyBikeActivity extends SMBBaseActivity implements OnFragmentInt
             } else {
                 startService(serviceIntent);
             }
-
             bindToService(serviceIntent);
+            // update recording status
+            Fragment currentFragment = getCurrentFragment();
+            if (currentFragment != null && currentFragment instanceof RecordingEventListener) {
+                ((RecordingEventListener) currentFragment).applySessionState(Session.SessionState.ACTIVE);
+            }
         }
     }
 

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/ActivitiesFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/ActivitiesFragment.java
@@ -9,6 +9,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import it.geosolutions.savemybike.R;
@@ -97,37 +100,39 @@ public class ActivitiesFragment extends Fragment implements RecordingEventListen
     // TODO: put in an upper class or refactor this interaction
     public void invalidateSessionStats(final Session session) {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        Fragment f = adapter.getItem(viewPager.getCurrentItem());
-        if(f instanceof RecordingEventListener) {
-            ((RecordingEventListener) f).invalidateSessionStats(session);
-
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).invalidateSessionStats(session);
+            }
         }
     };
     // TODO: put in an upper class or refactor this interaction
     public void selectVehicle(Vehicle vehicle) {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        Fragment f = adapter.getItem(viewPager.getCurrentItem());
-        if(f instanceof RecordingEventListener) {
-            ((RecordingEventListener) f).selectVehicle(vehicle);
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).selectVehicle(vehicle);
 
+            }
         }
     }
     // TODO: put in an upper class or refactor this interaction
     public void invalidateUI(Vehicle currentVehicle) {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        Fragment f = adapter.getItem(viewPager.getCurrentItem());
-        if(f instanceof RecordingEventListener) {
-            ((RecordingEventListener) f).invalidateUI(currentVehicle);
-
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).invalidateUI(currentVehicle);
+            }
         }
     }
 
     public void applySimulate(boolean simulate) {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        Fragment f = adapter.getItem(viewPager.getCurrentItem());
-        if(f instanceof RecordingEventListener) {
-            ((RecordingEventListener) f).applySimulate(simulate);
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).applySimulate(simulate);
 
+            }
         }
     }
 
@@ -135,20 +140,21 @@ public class ActivitiesFragment extends Fragment implements RecordingEventListen
     public void applySessionState(Session.SessionState stopped) {
         // refresh sessions view due to a record ending
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        Fragment f = adapter.getItem(viewPager.getCurrentItem());
-        if(f instanceof RecordingEventListener) {
-            ((RecordingEventListener) f).applySessionState(stopped);
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).applySessionState(stopped);
+            }
         }
     }
 
     @Override
     public void stopRecording() {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        if(adapter.getItem(1) instanceof StatsFragment) {
-            StatsFragment frag = (StatsFragment) adapter.getItem(1);
-            frag.refreshSessions();
+        for(Fragment f : getAllFragments(adapter)) {
+           if( f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).stopRecording();
+            }
         }
-
     }
     public void switchToSubFragment(int id) {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
@@ -157,5 +163,13 @@ public class ActivitiesFragment extends Fragment implements RecordingEventListen
             frag.switchTo(id);
         }
 
+    }
+    private  List<Fragment> getAllFragments(ViewPagerAdapter adapter) {
+        List<Fragment> allFragments = new LinkedList<>();
+        for (int i = 0; i < adapter.getCount(); i++) {
+            Fragment f = adapter.getItem(i);
+            allFragments.add(f);
+        }
+        return allFragments;
     }
 }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/StatsFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/StatsFragment.java
@@ -9,9 +9,15 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import butterknife.ButterKnife;
 import it.geosolutions.savemybike.R;
+import it.geosolutions.savemybike.model.Session;
+import it.geosolutions.savemybike.model.Vehicle;
 import it.geosolutions.savemybike.ui.adapters.ViewPagerAdapter;
+import it.geosolutions.savemybike.ui.callback.RecordingEventListener;
 
 /**
  * Created by Robert Oehler on 25.10.17.
@@ -19,7 +25,7 @@ import it.geosolutions.savemybike.ui.adapters.ViewPagerAdapter;
  * A fragment showing the stats of the session of the local database
  */
 
-public class StatsFragment extends Fragment {
+public class StatsFragment extends Fragment implements RecordingEventListener {
     private ViewPager viewPager;
     /**
      * inflate and setup the view of this fragment
@@ -47,12 +53,7 @@ public class StatsFragment extends Fragment {
         TabLayout tabLayout = view.findViewById(R.id.tabs);
         tabLayout.setupWithViewPager(viewPager);
     }
-    // TODO: improve this interface
-    public void refreshSessions() {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        SessionsFragment f = (SessionsFragment) adapter.getItem(1);
-        f.invalidateSessions();
-    }
+   
     public void switchTo(int id) {
         switch (id) {
             case R.id.tracks_list:
@@ -62,5 +63,73 @@ public class StatsFragment extends Fragment {
                 viewPager.setCurrentItem(1);
                 break;
         }
+    }
+    // TODO: put in an upper class or refactor this interaction
+    public void invalidateSessionStats(final Session session) {
+        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).invalidateSessionStats(session);
+            }
+        }
+    };
+    // TODO: put in an upper class or refactor this interaction
+    public void selectVehicle(Vehicle vehicle) {
+        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).selectVehicle(vehicle);
+
+            }
+        }
+    }
+
+    // TODO: put in an upper class or refactor this interaction
+    public void invalidateUI(Vehicle currentVehicle) {
+        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).invalidateUI(currentVehicle);
+            }
+        }
+    }
+
+    public void applySimulate(boolean simulate) {
+        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).applySimulate(simulate);
+
+            }
+        }
+    }
+
+    @Override
+    public void applySessionState(Session.SessionState stopped) {
+        // refresh sessions view due to a record ending
+        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+        for(Fragment f : getAllFragments(adapter)) {
+            if (f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).applySessionState(stopped);
+            }
+        }
+    }
+
+    @Override
+    public void stopRecording() {
+        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+        for(Fragment f : getAllFragments(adapter)) {
+            if( f instanceof RecordingEventListener) {
+                ((RecordingEventListener) f).stopRecording();
+            }
+        }
+    }
+    private List<Fragment> getAllFragments(ViewPagerAdapter adapter) {
+        List<Fragment> allFragments = new LinkedList<>();
+        for (int i = 0; i < adapter.getCount(); i++) {
+            Fragment f = adapter.getItem(i);
+            allFragments.add(f);
+        }
+        return allFragments;
     }
 }

--- a/app/src/main/res/drawable/ic_cloud_upload.xml
+++ b/app/src/main/res/drawable/ic_cloud_upload.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
+</vector>

--- a/app/src/main/res/layout/empty_sessions_recording.xml
+++ b/app/src/main/res/layout/empty_sessions_recording.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+
+    >
+
+    <ImageView
+        android:id="@+id/empty_icon"
+        android:layout_width="88dp"
+        android:layout_height="83dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="88dp"
+        android:alpha="0.3"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.18"
+        app:srcCompat="@drawable/ic_record" />
+
+    <TextView
+        android:id="@+id/empty_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/recording_sessions"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/empty_icon" />
+
+    <TextView
+        android:id="@+id/empty_description"
+        android:layout_width="280dp"
+        android:layout_height="82dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="44dp"
+        android:gravity="center"
+        android:text="@string/recording_sessions_description"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/empty_text"
+        app:layout_constraintVertical_bias="0.0" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/empty_sessions_uploading.xml
+++ b/app/src/main/res/layout/empty_sessions_uploading.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:visibility="gone"
+
+    >
+
+    <ImageView
+        android:id="@+id/empty_icon"
+        android:layout_width="88dp"
+        android:layout_height="83dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="88dp"
+        android:alpha="0.3"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.18"
+        app:srcCompat="@drawable/ic_cloud_upload" />
+
+    <TextView
+        android:id="@+id/empty_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/uploading_sessions"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/empty_icon" />
+
+    <TextView
+        android:id="@+id/empty_description"
+        android:layout_width="280dp"
+        android:layout_height="82dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="44dp"
+        android:gravity="center"
+        android:text="@string/uploading_sessions_description"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/empty_text"
+        app:layout_constraintVertical_bias="0.0" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_sessions.xml
+++ b/app/src/main/res/layout/fragment_sessions.xml
@@ -23,6 +23,8 @@
     </LinearLayout>
 
     <include android:id="@+id/empty_sessions" layout="@layout/empty_sessions" />
+    <include android:id="@+id/empty_sessions_uploading" layout="@layout/empty_sessions_uploading" />
+    <include android:id="@+id/empty_sessions_recording" layout="@layout/empty_sessions_recording" />
 
     <LinearLayout
         android:id="@+id/content_layout"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-</adaptive-icon>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -303,4 +303,8 @@
     <string name="gps_disabled_title">GPS Disabilitato</string>
     <string name="gps_disabled_description">Il Gps è disabilitato. Per registrare è necessario abilitare il GPS sul tuo dispositivo</string>
     <string name="gps_enable">Abilita GPS</string>
+    <string name="uploading_sessions">Invio tracce in corso...</string>
+    <string name="uploading_sessions_description">Le tue registrazione stanno per essere prese in carico dal sistema. A breve le potrai vedere nella lista delle tracce. Assicurati di aggiornare la lista, trascinandola in basso col dito, per ricevere le nuove tracce elaborate</string>
+    <string name="recording_sessions">Registrazione in corso</string>
+    <string name="recording_sessions_description">Non è possibile visualizzare le tracce da inviare durante la registrazione. Riprovare a registrazione conclusa</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -338,4 +338,8 @@
     <string name="gps_disabled_title">GPS Disabled</string>
     <string name="gps_disabled_description">Gps is disabled, in order to use the application properly you need to enable GPS of your device</string>
     <string name="gps_enable">Enable GPS</string>
+    <string name="uploading_sessions">Sending Tracks...</string>
+    <string name="uploading_sessions_description">Your tracks will be loaded into the system soon and you will see them in the tracks list. Make you sure to update the track list dragging down the list with the finger </string>
+    <string name="recording_sessions">Recording...</string>
+    <string name="recording_sessions_description">You can not see tracks to send during a recording session. Try again when the recording session is finished</string>
 </resources>


### PR DESCRIPTION
Hide the "To Send" list while recording or uploading. This avoid to see temporary data waiting for a proper model refactor.

While recording: 
![image](https://user-images.githubusercontent.com/1279510/47649009-1f28df00-db7c-11e8-9fe1-da8d9dc3260f.png)

While uploading: 
![image](https://user-images.githubusercontent.com/1279510/47649067-56978b80-db7c-11e8-9185-85c2b573a047.png)


other minor fixes:
 - Removed launcher icons that didn't work properly on latest versions of android. 