### PR TITLE
Refresh tracks and Sessions on track validation notification. 

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/FirebaseService.java
+++ b/app/src/main/java/it/geosolutions/savemybike/FirebaseService.java
@@ -22,12 +22,11 @@ import it.geosolutions.savemybike.ui.activity.LoginActivity;
 public class FirebaseService extends FirebaseMessagingService {
     private static final String TAG = FirebaseService.class.getSimpleName();
     public static final String MESSAGE_NAME_KEY = "message_name";
+
     public static final class MESSAGE_TYPES {
         public static final String TRACK_VALIDATED = "track_validated";
         public static final String BADGE_WON = "badge_won";
         public static final String PRIZE_WON = "prize_won";
-
-
     }
     public static final class VALIDATION_KEYS {
         public static final String IS_VALID = "is_valid";
@@ -96,12 +95,21 @@ public class FirebaseService extends FirebaseMessagingService {
      */
     public void handleInvalid(String errors ) {
         getUserNotificationManager().notifyTrackInvalid(errors);
+        // send broadcast to update UI
+        Intent intent = new Intent();
+        intent.setAction(MESSAGE_TYPES.TRACK_VALIDATED);
+        sendBroadcast(intent);
     }
     /**
      * Handles a notification of an valid track
      */
     public void handleValid() {
         getUserNotificationManager().notifyTrackValid();
+
+        // send broadcast to update UI
+        Intent intent = new Intent();
+        intent.setAction(MESSAGE_TYPES.TRACK_VALIDATED);
+        sendBroadcast(intent);
     }
 
     public void handleBadgeWon(String badgeName) {

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/ActivitiesFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/ActivitiesFragment.java
@@ -99,68 +99,82 @@ public class ActivitiesFragment extends Fragment implements RecordingEventListen
 
     // TODO: put in an upper class or refactor this interaction
     public void invalidateSessionStats(final Session session) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).invalidateSessionStats(session);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).invalidateSessionStats(session);
+                }
             }
         }
     };
     // TODO: put in an upper class or refactor this interaction
     public void selectVehicle(Vehicle vehicle) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).selectVehicle(vehicle);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).selectVehicle(vehicle);
 
+                }
             }
         }
     }
     // TODO: put in an upper class or refactor this interaction
     public void invalidateUI(Vehicle currentVehicle) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).invalidateUI(currentVehicle);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for(Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).invalidateUI(currentVehicle);
+                }
             }
         }
     }
 
     public void applySimulate(boolean simulate) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).applySimulate(simulate);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).applySimulate(simulate);
 
+                }
             }
         }
     }
 
     @Override
     public void applySessionState(Session.SessionState stopped) {
-        // refresh sessions view due to a record ending
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).applySessionState(stopped);
+        if(viewPager != null) {
+            // refresh sessions view due to a record ending
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).applySessionState(stopped);
+                }
             }
         }
     }
 
     @Override
     public void stopRecording() {
+        if(viewPager != null) {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
         for(Fragment f : getAllFragments(adapter)) {
-           if( f instanceof RecordingEventListener) {
+            if (f instanceof RecordingEventListener) {
                 ((RecordingEventListener) f).stopRecording();
             }
         }
+        }
     }
     public void switchToSubFragment(int id) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        if(adapter.getItem(1) instanceof StatsFragment) {
-            StatsFragment frag = (StatsFragment) adapter.getItem(1);
-            frag.switchTo(id);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            if (adapter.getItem(1) instanceof StatsFragment) {
+                StatsFragment frag = (StatsFragment) adapter.getItem(1);
+                frag.switchTo(id);
+            }
         }
 
     }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/SessionsFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/SessionsFragment.java
@@ -3,6 +3,10 @@ package it.geosolutions.savemybike.ui.fragment;
 import android.Manifest;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -20,6 +24,7 @@ import java.util.ArrayList;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.internal.DebouncingOnClickListener;
+import it.geosolutions.savemybike.FirebaseService;
 import it.geosolutions.savemybike.R;
 import it.geosolutions.savemybike.data.server.S3Manager;
 import it.geosolutions.savemybike.model.Session;
@@ -285,5 +290,27 @@ public class SessionsFragment extends Fragment implements RecordingEventListener
         // need to show tracks when recording sessions is stopped
         updateListStatus(null);
         invalidateSessions();
+    }
+
+    // MANAGE NOTIFICATIONS
+    private BroadcastReceiver receiver;
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                updateListStatus(null);
+                invalidateSessions();
+            }
+        };
+        getActivity().registerReceiver(receiver, new IntentFilter(FirebaseService.MESSAGE_TYPES.TRACK_VALIDATED));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getActivity().unregisterReceiver(receiver);
     }
 }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/StatsFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/StatsFragment.java
@@ -66,40 +66,47 @@ public class StatsFragment extends Fragment implements RecordingEventListener {
     }
     // TODO: put in an upper class or refactor this interaction
     public void invalidateSessionStats(final Session session) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).invalidateSessionStats(session);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).invalidateSessionStats(session);
+                }
             }
         }
     };
     // TODO: put in an upper class or refactor this interaction
     public void selectVehicle(Vehicle vehicle) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).selectVehicle(vehicle);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).selectVehicle(vehicle);
 
+                }
             }
         }
     }
 
     // TODO: put in an upper class or refactor this interaction
     public void invalidateUI(Vehicle currentVehicle) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).invalidateUI(currentVehicle);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for(Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).invalidateUI(currentVehicle);
+                }
             }
         }
     }
 
     public void applySimulate(boolean simulate) {
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).applySimulate(simulate);
-
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).applySimulate(simulate);
+                }
             }
         }
     }
@@ -107,20 +114,24 @@ public class StatsFragment extends Fragment implements RecordingEventListener {
     @Override
     public void applySessionState(Session.SessionState stopped) {
         // refresh sessions view due to a record ending
-        ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if (f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).applySessionState(stopped);
+        if(viewPager != null) {
+            ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
+            for (Fragment f : getAllFragments(adapter)) {
+                if (f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).applySessionState(stopped);
+                }
             }
         }
     }
 
     @Override
     public void stopRecording() {
+        if(viewPager != null) {
         ViewPagerAdapter adapter = (ViewPagerAdapter) viewPager.getAdapter();
-        for(Fragment f : getAllFragments(adapter)) {
-            if( f instanceof RecordingEventListener) {
-                ((RecordingEventListener) f).stopRecording();
+            for(Fragment f : getAllFragments(adapter)) {
+                if( f instanceof RecordingEventListener) {
+                    ((RecordingEventListener) f).stopRecording();
+                }
             }
         }
     }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TracksFragment.java
@@ -2,7 +2,10 @@ package it.geosolutions.savemybike.ui.fragment;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -18,6 +21,7 @@ import java.util.ArrayList;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import it.geosolutions.savemybike.FirebaseService;
 import it.geosolutions.savemybike.R;
 import it.geosolutions.savemybike.data.server.RetrofitClient;
 import it.geosolutions.savemybike.data.server.SMBRemoteServices;
@@ -175,6 +179,25 @@ public class TracksFragment extends Fragment {
                 n.setVisibility(show && noNetwork ? View.VISIBLE : View.GONE);
             }
         }
+    }
+    private BroadcastReceiver receiver;
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                getTracks();
+            }
+        };
+        getActivity().registerReceiver(receiver, new IntentFilter(FirebaseService.MESSAGE_TYPES.TRACK_VALIDATED));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getActivity().unregisterReceiver(receiver);
     }
 }
 


### PR DESCRIPTION
Actually, when user receives a notification of track validated, the sessions and tracks list is not updated. The user have to drag the view and this is misleading.
I fixed it sending a BroadcastNotification when validation notification is received. The 2 Fragments register as broadcast receivers. 

Minor Fixes when when resume application, sometimes refresh handlers throw NullPointerExceptions because components (viewPagers) that are not initialized. 