### PR TITLE
Externalized and grouped dev resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # smb-app
 SaveMyBike mobile app
 
-## Setup of GOOGLE_API_KEY
+## Setup of GOOGLE_API_KEY and firebase secrets
+
+To setup the application you have to setup the following resources:
+- app/google-services.json (download it from firebase console: setting --> General --> your applications)
+- `google_maps_api.xml`, depending on your build environment ( TODO: externalize also this )
 
 ### Beta
 
@@ -13,20 +17,7 @@ Replace in `app/src/debug/res/values/google_maps_api.xml` `YOUR_KEY_HERE` with t
 
 ## Development
 
-Configure the application as following to setup to work with dev resources.
+From next commits after 0.9-beta the constants of the dev and production are managed directly in build.gradle. Resources like `auth_config.json` are managed as build resources (`app/src/main/res...` vs `app/rsc/debug/res`)
 
- - `app/src/main/java/it/geosolutions/savemybike/data/Constants.java`: change PORTAL_ENDPOINT and UPLOAD_RESOURCE to related dev URLs:
 
-```
-    public final static String PORTAL_ENDPOINT = "https://dev.savemybike.geo-solutions.it/"; // DEV
-    public final static String UPLOAD_RESOURCE = "upload-dev/"; // DEV
-```
-
- - `app/src/main/res/raw/auth_config.json`: change discovery_uri as following
-
- ```
- discovery_uri": "https://dev.savemybike.geo-solutions.it/auth/realms/save-my-bike/.well-known/openid-configuration",
- ```
-
-  - app/google-services.json (download it from firebase console: setting --> General --> your applications)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,11 +25,15 @@ android {
     buildTypes {
         debug {
             versionNameSuffix ".debug"
+            buildConfigField "String", "PORTAL_ENDPOINT", '"https://dev.savemybike.geo-solutions.it/"'
+            buildConfigField "String", "UPLOAD_RESOURCE", '"upload-dev/"'
             resValue "string", "app_version",
                     "${defaultConfig.versionName}${versionNameSuffix}"
         }
         beta {
             versionNameSuffix ".beta"
+            buildConfigField "String", "PORTAL_ENDPOINT", '"https://goodgo.savemybike.geo-solutions.it/"'
+            buildConfigField "String", "UPLOAD_RESOURCE", '"upload/"'
             minifyEnabled false
             resValue "string", "app_version",
                     "${defaultConfig.versionName}${versionNameSuffix}"
@@ -38,6 +42,8 @@ android {
         }
         release {
             minifyEnabled false
+            buildConfigField "String", "PORTAL_ENDPOINT", '"https://goodgo.savemybike.geo-solutions.it/"'
+            buildConfigField "String", "UPLOAD_RESOURCE", '"upload/"'
             resValue "string", "app_version",
                 "${defaultConfig.versionName}"
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/src/debug/res/raw/auth_config.json
+++ b/app/src/debug/res/raw/auth_config.json
@@ -1,0 +1,11 @@
+{
+  "client_id": "smb-portal",
+  "redirect_uri": "it.geosolutions.savemybike:/oauth2redirect",
+  "authorization_scope": "openid email profile",
+  "discovery_uri": "https://dev.savemybike.geo-solutions.it/auth/realms/save-my-bike/.well-known/openid-configuration",
+  "authorization_endpoint_uri": "",
+  "token_endpoint_uri": "",
+  "registration_endpoint_uri": "",
+  "user_info_endpoint_uri": "",
+  "https_required": true
+}

--- a/app/src/main/java/it/geosolutions/savemybike/data/Constants.java
+++ b/app/src/main/java/it/geosolutions/savemybike/data/Constants.java
@@ -1,5 +1,7 @@
 package it.geosolutions.savemybike.data;
 
+import it.geosolutions.savemybike.BuildConfig;
+
 /**
  * Created by Robert Oehler on 02.11.17.
  *
@@ -7,14 +9,12 @@ package it.geosolutions.savemybike.data;
 
 public class Constants {
 
-    public final static String PORTAL_ENDPOINT = "https://goodgo.savemybike.geo-solutions.it/";
-    // public final static String PORTAL_ENDPOINT = "https://dev.savemybike.geo-solutions.it/"; // DEV
+    public final static String PORTAL_ENDPOINT = BuildConfig.PORTAL_ENDPOINT;
 
     /**
      * AWS method used for the current environment
      */
-    public final static String UPLOAD_RESOURCE = "upload/";
-    // public final static String UPLOAD_RESOURCE = "upload-dev/"; // DEV
+    public final static String UPLOAD_RESOURCE = BuildConfig.UPLOAD_RESOURCE;
 
     public final static int DEFAULT_DATA_READ_INTERVAL = 1000;
     public final static int DEFAULT_PERSISTENCE_INTERVAL = 15000;


### PR DESCRIPTION
This pull request modifies build to setup `debug` build to use dev resources, while `beta` and the others build types use production resources.

Still to do: 
 - Manage secrets (`google-services.json`, `google_maps_api.xml`)