### PR TITLE
Fix #85 Implemented bikes observations map

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,7 +82,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.activity.TrackDetailsActivity" />
-        <activity android:name=".ui.activity.BikeDetailsActivity" />
+        <activity android:name=".ui.activity.BikeDetailsActivity" android:screenOrientation="portrait"/>
         <activity
             android:name=".ui.activity.CompleteProfile"
             android:label="@string/title_activity_complete_profile"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.activity.TrackDetailsActivity" />
+        <activity android:name=".ui.activity.BikeDetailsActivity" />
         <activity
             android:name=".ui.activity.CompleteProfile"
             android:label="@string/title_activity_complete_profile"

--- a/app/src/main/java/it/geosolutions/savemybike/data/server/SMBRemoteServices.java
+++ b/app/src/main/java/it/geosolutions/savemybike/data/server/SMBRemoteServices.java
@@ -41,6 +41,9 @@ public interface SMBRemoteServices {
     @GET("api/my-bikes")
     Call<PaginatedResult<Bike>> getMyBikes();
 
+    @GET("api/my-bike-observations/")
+    Call<ResponseBody> getBikeObservations(@Query("bike") String id);
+
     @POST("api/my-bike-statuses/")
     Call<Object> sendNewBikeStatus(
             @Body CurrentStatus newStatus
@@ -67,7 +70,7 @@ public interface SMBRemoteServices {
     @GET("api/my-competitions-won/")
     Call<PaginatedResult<Competition>> getMyPrizes();
 
-    @PUT("api/my-devices/{token}")
+    @PUT("api/my-devices/{token}/")
     Call<ResponseBody> updateDevice(@Path("token") String token, @Body Device device);
 
     @POST("api/my-devices/")

--- a/app/src/main/java/it/geosolutions/savemybike/model/CurrentStatus.java
+++ b/app/src/main/java/it/geosolutions/savemybike/model/CurrentStatus.java
@@ -3,10 +3,12 @@ package it.geosolutions.savemybike.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serializable;
+
 /**
  * Created by Lorenzo Pini on 05/07/2018.
  */
-public class CurrentStatus {
+public class CurrentStatus implements Serializable {
 
     @SerializedName("lost")
     @Expose

--- a/app/src/main/java/it/geosolutions/savemybike/model/Observation.java
+++ b/app/src/main/java/it/geosolutions/savemybike/model/Observation.java
@@ -1,0 +1,28 @@
+package it.geosolutions.savemybike.model;
+
+import android.util.Log;
+
+import com.google.gson.JsonObject;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ *
+ */
+public class Observation {
+    public String id;
+    public String observedAt;
+    public Observation(JSONObject obj) {
+        try {
+            id = obj.getString("id");
+            JSONObject properties = obj.getJSONObject("properties");
+            if (properties != null) {
+                observedAt = obj.getString("observed_at");
+            }
+        } catch (JSONException e) {
+            Log.e("Observation", "can not parse json object for observation");
+        }
+    }
+
+}

--- a/app/src/main/java/it/geosolutions/savemybike/model/Observation.java
+++ b/app/src/main/java/it/geosolutions/savemybike/model/Observation.java
@@ -13,12 +13,14 @@ import org.json.JSONObject;
 public class Observation {
     public String id;
     public String observedAt;
+    public String address;
     public Observation(JSONObject obj) {
         try {
             id = obj.getString("id");
             JSONObject properties = obj.getJSONObject("properties");
             if (properties != null) {
-                observedAt = obj.getString("observed_at");
+                observedAt = properties.getString("observed_at");
+                address = properties.getString("address");
             }
         } catch (JSONException e) {
             Log.e("Observation", "can not parse json object for observation");

--- a/app/src/main/java/it/geosolutions/savemybike/ui/BikeAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/BikeAdapter.java
@@ -12,13 +12,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
-import com.google.android.gms.maps.MapFragment;
-import com.google.android.gms.maps.SupportMapFragment;
 
 import java.util.List;
 
@@ -58,11 +54,12 @@ public abstract class BikeAdapter extends ArrayAdapter<Bike> {
         }
 
         final Bike bike = getItem(position);
+        
 
         if (bike != null) {
             final TextView titleTv = view.findViewById(R.id.bike_title);
             final ImageView imageView = view.findViewById(R.id.bike_image);
-
+            imageView.setOnClickListener((View v) -> onItemClick(bike));
             if (bike.getNickname() != null) {
                 titleTv.setText(bike.getNickname());
             } else {
@@ -111,5 +108,8 @@ public abstract class BikeAdapter extends ArrayAdapter<Bike> {
         }
         return view;
     }
+
+    protected abstract void onItemClick(Bike bike);
+
     public abstract void updateStatus(Bike bike, String details);
 }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/BikeDetailsActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/BikeDetailsActivity.java
@@ -1,0 +1,445 @@
+package it.geosolutions.savemybike.ui.activity;
+
+
+import android.app.Activity;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.BottomSheetBehavior;
+import android.support.design.widget.TabLayout;
+import android.support.v4.view.ViewPager;
+import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.google.android.gms.maps.CameraUpdate;
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.SupportMapFragment;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.Marker;
+import com.google.maps.android.data.Feature;
+import com.google.maps.android.data.geojson.GeoJsonFeature;
+import com.google.maps.android.data.geojson.GeoJsonLayer;
+import com.google.maps.android.data.geojson.GeoJsonPoint;
+import com.google.maps.android.data.geojson.GeoJsonPointStyle;
+
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import it.geosolutions.savemybike.R;
+import it.geosolutions.savemybike.data.server.RetrofitClient;
+import it.geosolutions.savemybike.data.server.SMBRemoteServices;
+import it.geosolutions.savemybike.model.Bike;
+import it.geosolutions.savemybike.model.Observation;
+import it.geosolutions.savemybike.ui.adapters.ViewPagerAdapter;
+import it.geosolutions.savemybike.ui.callback.OnFragmentInteractionListener;
+import it.geosolutions.savemybike.ui.custom.BottomSheetBehaviorGoogleMapsLike;
+import it.geosolutions.savemybike.ui.fragment.BikeDetailsFragment;
+import it.geosolutions.savemybike.ui.fragment.BikeListFragment;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+
+/**
+ * @author Lorenzo Natali, GeoSolutions S.a.s.
+ * Activity for bike details view. Manages initialization of the map and various fragments for
+ * the details of a bike.
+ *
+ */
+public class BikeDetailsActivity extends SMBBaseActivity implements OnMapReadyCallback, OnFragmentInteractionListener {
+    private static final String TAG = "BIKEDETAILS";
+    public static final String OBSERVED_AT = "observed_at";
+    private static final String PROPERTY_OBSERVED_AT = OBSERVED_AT;
+    private static final String LAST_UPDATES = "LAST_UPDATES";
+    public static final String ADDRESS = "address";
+    public static final String REPORTER_NAME = "reporter_name";
+    private GoogleMap mMap;
+    GeoJsonLayer layer;
+    private Bike bike;
+    JSONObject geojson;
+    private boolean layoutDone = false;
+    public static final String BIKE = "BIKE";
+    View bottomSheet;
+    BottomSheetBehaviorGoogleMapsLike bottomSheetBehaviour;
+    View tapActionLayout;
+    Toolbar toolbar;
+    BikeDetailsFragment details = new BikeDetailsFragment();
+
+    @BindView(R.id.bike_name) TextView bikeName;
+    private boolean firstRender =true;
+
+    /**
+     * Flag to skip move to re-center the map, used to
+     * skip map resize when maker has been selected, clicking on a
+     * feature
+     */
+    private boolean skipMove;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        bike = (Bike) getIntent().getExtras().getSerializable(BIKE);
+        details.setEventsCallbacks(new BikeDetailsFragment.EventCallbacks() {
+            @Override
+            public void onSelect(Observation o) {
+                selectFeature(o.id);
+            }
+        });
+        loadData();
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.bike_details);
+        View ev = findViewById(R.id.emptyView);
+
+        bindDependencies();
+        ev.getViewTreeObserver().addOnGlobalFocusChangeListener( (view, a2) -> {
+            layoutDone = true;
+            updatePadding();
+
+        });
+        if(ev != null) {
+            ev.setVisibility(View.GONE);
+        }
+
+        // Obtain the SupportMapFragment and get notified when the map is ready to be used.
+        SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.map);
+        mapFragment.getMapAsync(this);
+        setUpBottomSheet();
+        setupActionBar();
+        setupViewPager();
+
+
+    }
+
+    private void selectFeature(String id) {
+        GeoJsonFeature feature = getById(id);
+        bottomSheetBehaviour.setState(BottomSheetBehaviorGoogleMapsLike.STATE_ANCHOR_POINT);
+        skipMove = true;
+        details.setSelected(id);
+        if(mMap != null) {
+            centerMapTo(id);
+        }
+    }
+
+    private void setupViewPager() {
+        ViewPager viewPager = findViewById(R.id.bike_details_viewpager);
+        ViewPagerAdapter adapter = new ViewPagerAdapter(getSupportFragmentManager());
+
+        // Add Fragments to adapter one by one
+        adapter.addFragment(details, getBaseContext().getResources().getString(R.string.last_observations));
+        viewPager.setAdapter(adapter);
+
+        TabLayout tabLayout = findViewById(R.id.bike_details_tabs);
+        tabLayout.setupWithViewPager(viewPager);
+    }
+
+    private void setupActionBar() {
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setHomeButtonEnabled(true);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+        findViewById(R.id.bikes_bar_layout).bringToFront();
+        toolbar.bringToFront();
+    }
+
+    private void bindDependencies() {
+        ButterKnife.bind(this);
+        if(bottomSheet == null) {
+            bottomSheet = findViewById(R.id.bike_details_bottom_sheet);
+        }
+        if(tapActionLayout == null) {
+            tapActionLayout = findViewById(R.id.tap_action_layout);
+        }
+        if(toolbar == null) {
+            toolbar = findViewById(R.id.bike_details_toolbar);
+        }
+    }
+    private void setUpBottomSheet() {
+        bottomSheetBehaviour = BottomSheetBehaviorGoogleMapsLike.from(bottomSheet);
+
+        bottomSheetBehaviour.setPeekHeight(300);
+
+        bottomSheetBehaviour.setState(BottomSheetBehaviorGoogleMapsLike.STATE_COLLAPSED);
+        bottomSheetBehaviour.addBottomSheetCallback(new BottomSheetBehaviorGoogleMapsLike.BottomSheetCallback() {
+                    @Override
+                    public void onStateChanged(@NonNull View bottomSheet, int newState) {
+                        switch (newState) {
+                            case BottomSheetBehaviorGoogleMapsLike.STATE_COLLAPSED:
+                                updatePadding();
+                                break;
+                            case BottomSheetBehaviorGoogleMapsLike.STATE_DRAGGING:
+
+                                break;
+                            case BottomSheetBehaviorGoogleMapsLike.STATE_EXPANDED:
+                                updatePadding();
+                                break;
+                            case BottomSheetBehaviorGoogleMapsLike.STATE_ANCHOR_POINT:
+                                // note; map resize in this case shold be performed only if the state change is due to a user bottom sheet interaction
+                                // when this happens programmatically, updatePadding should be triggered, but the map should not be re-centered
+                                // TODO: now it is i
+                                updatePadding();
+                                break;
+                            case BottomSheetBehaviorGoogleMapsLike.STATE_HIDDEN:
+                                updatePadding();
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    @Override
+                    public void onSlide(@NonNull View bottomSheet, float slideOffset) {
+                    }
+        });
+        tapActionLayout.setOnClickListener((v) -> {
+            switch (bottomSheetBehaviour.getState()) {
+                case BottomSheetBehaviorGoogleMapsLike.STATE_COLLAPSED:
+                    bottomSheetBehaviour.setState(BottomSheetBehaviorGoogleMapsLike.STATE_ANCHOR_POINT);
+            }
+        });
+    }
+
+    public void updatePadding() {
+        if(mMap != null && layoutDone) {
+            LatLngBounds bounds = mMap.getProjection().getVisibleRegion().latLngBounds;
+
+            int bottomPadding = getDefaultBottomPadding();
+            if( bottomSheetBehaviour.getState() == BottomSheetBehaviorGoogleMapsLike.STATE_ANCHOR_POINT
+                 // this is a trick to allow to correct center the map anyway if the user selects an item when the
+                 // sheet is fully expanded
+                 || bottomSheetBehaviour.getState() == BottomSheetBehaviorGoogleMapsLike.STATE_EXPANDED   ) {
+                int height = findViewById(R.id.map).getMeasuredHeight();
+
+                bottomPadding = height - getDefaultBottomPadding() - getResources().getDimensionPixelSize(R.dimen.bottom_sheet_anchor_point);
+
+            }
+            mMap.setPadding(0, 150, 0, bottomPadding);
+            if(skipMove) {
+                // when the updatePadding follows a feature selection
+                // that trigger map resize but we don't have to adjust it
+                skipMove = false;
+            } else if(firstRender) {
+                mMap.moveCamera(CameraUpdateFactory
+                        .newLatLngBounds(bounds, 10));
+                firstRender = false;
+            } else {
+                mMap.animateCamera(CameraUpdateFactory
+                        .newLatLngBounds(bounds, 10));
+            }
+
+
+
+        }
+    }
+    private void loadData() {
+        setLoading(true);
+        RetrofitClient client = RetrofitClient.getInstance(this);
+        SMBRemoteServices portalServices = client.getPortalServices();
+        portalServices.getBikeObservations(bike.getShort_uuid()).enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                try {
+                    geojson = new JSONObject(response.body().string());
+                    Bundle args = new Bundle();
+                    details.updateListData(geojson);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                } catch (JSONException e) {
+                    Log.e(TAG, "Unable to read bikes positions");
+                }
+                if(bike != null && geojson != null) {
+                    displayData();
+                } else {
+                    showNoData(null);
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable t) {
+                setLoading(false);
+                showNoData(t instanceof SocketTimeoutException ? "timeout" : null);
+
+            }
+        });
+    }
+
+    /**
+     * Manipulates the map once available.
+     * This callback is triggered when the map is ready to be used.
+     * If Google Play services is not installed on the device, the user will be prompted to install
+     * it inside the SupportMapFragment. This method will only be triggered once the user has
+     * installed Google Play services and returned to the app.
+     */
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        mMap = googleMap;
+        displayData();
+    }
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+    private void displayData() {
+        // setup data in map
+        // update item view
+        if(geojson != null) {
+            View view = findViewById(R.id.session_row);
+            inflateBikeDataToRecordView(bike, view);
+            // update map
+            if(mMap != null) {
+                if(layoutDone) {
+                    mMap.setPadding(0, 150, 0, getDefaultBottomPadding());
+                }
+                layer = new GeoJsonLayer(mMap, geojson);
+
+                LatLngBounds.Builder builder = LatLngBounds.builder();
+                Iterable<GeoJsonFeature> features = layer.getFeatures();
+                GeoJsonFeature last = getLastFeature();
+                for(GeoJsonFeature f: layer.getFeatures()) {
+                    // calculate bounding box
+                    builder.include(((GeoJsonPoint) f.getGeometry()).getCoordinates());
+
+                    // create popup
+                    String address = null;
+                    String observed_at = null;
+                    String reporter_name = null;
+                    ArrayList<String> snipplets = new ArrayList<String>();
+                    if(f.hasProperty(REPORTER_NAME) && !"".equals(f.getProperty(REPORTER_NAME))) {
+                        reporter_name = f.getProperty(REPORTER_NAME);
+                        if(reporter_name != null) {
+                            snipplets.add(reporter_name);
+                        }
+                    }
+                    if (f.hasProperty(ADDRESS) && !"".equals(f.getProperty(ADDRESS))) {
+                        address = f.getProperty(ADDRESS);
+                        if(address != null) {
+                            snipplets.add(address);
+                        }
+                    }
+                    if (f.hasProperty(OBSERVED_AT) && !"".equals(f.getProperty(OBSERVED_AT))) {
+                        observed_at = f.getProperty(OBSERVED_AT);
+                    }
+
+                    GeoJsonPointStyle pointStyle = new GeoJsonPointStyle();
+                    if(observed_at != null) {
+                        String dateFormatted = DateTimeFormat.forPattern("dd MMM, 'ore' HH:mm").print(new DateTime((observed_at)));
+                        pointStyle.setTitle(dateFormatted);
+                    }
+                    pointStyle.setSnippet(TextUtils.join(", ", snipplets));
+                    f.setPointStyle(pointStyle);
+                }
+                layer.addLayerToMap();
+                layer.setOnFeatureClickListener((feature) -> {
+                    selectFeature(feature.getId());
+                });
+                // zoom to bounding box
+                try {
+                    LatLngBounds bounds = builder.build();
+                    mMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 40));
+                } catch(IllegalStateException e) {
+                  Log.w(TAG, "No observation");
+
+                    showNoData("noPoints");
+                }finally {
+                    setLoading(false);
+                }
+
+            }
+        }
+    }
+
+    public void inflateBikeDataToRecordView(Bike bike, View view) {
+        if(bike.getName() != null) {
+            bikeName.setText(bike.getName());
+        }
+    }
+
+    /**
+     * Creates the (Geo)JSONObject required by the GeoJsonLayer
+     * @return the JSONObject
+     */
+    @Override
+    public void onFragmentInteraction(Uri uri) {
+        // NO action needed for this handler
+    }
+    public void setLoading(boolean loading) {
+        View v = findViewById(R.id.loading_container);
+        if(v != null) {
+            v.setVisibility(loading ? View.VISIBLE : View.GONE);
+        }
+    }
+    public void showNoData(String errorType) {
+        View v = findViewById(R.id.emptyView);
+        if(v != null) {
+            v.setVisibility(View.VISIBLE);
+            if(errorType == "timeout") {
+                ((TextView) v.findViewById(R.id.empty_description)).setText(R.string.server_took_too_long_to_respond);
+            }
+        }
+    }
+    public void centerMapTo(String id) {
+        if(layer != null & mMap != null) {
+            for(GeoJsonFeature f : layer.getFeatures()) {
+                if(id == f.getId()) {
+                    GeoJsonPoint p = (GeoJsonPoint) f.getGeometry();
+                    mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(p.getCoordinates(), 14));
+                }
+            };
+        }
+    }
+    private GeoJsonFeature getLastFeature() {
+        GeoJsonFeature last = null;
+        if(layer != null & mMap != null) {
+            for(GeoJsonFeature f : layer.getFeatures()) {
+                if(last == null || f.getProperty(PROPERTY_OBSERVED_AT).compareTo(last.getProperty(PROPERTY_OBSERVED_AT)) < 0) {
+                    last = f;
+                }
+            }
+        }
+        return last;
+    }
+    private GeoJsonFeature getById(String id) {
+        GeoJsonFeature last = null;
+        if(layer != null & mMap != null) {
+            for(GeoJsonFeature f : layer.getFeatures()) {
+                if(f.getId() == id) {
+                    return f;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void onRequestPermissionGrant(PermissionIntent permissionIntent) {
+        // nothing to do, this activity don't require permission.
+    }
+
+    public int getDefaultBottomPadding() {
+        return getSupportActionBar().getHeight();
+    }
+}

--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/BikeDetailsActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/BikeDetailsActivity.java
@@ -125,8 +125,6 @@ public class BikeDetailsActivity extends SMBBaseActivity implements OnMapReadyCa
         setUpBottomSheet();
         setupActionBar();
         setupViewPager();
-
-
     }
 
     private void selectFeature(String id) {
@@ -373,8 +371,8 @@ public class BikeDetailsActivity extends SMBBaseActivity implements OnMapReadyCa
     }
 
     public void inflateBikeDataToRecordView(Bike bike, View view) {
-        if(bike.getName() != null) {
-            bikeName.setText(bike.getName());
+        if(bike.getNickname() != null) {
+            bikeName.setText(bike.getNickname());
         }
     }
 

--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/BikeDetailsActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/BikeDetailsActivity.java
@@ -204,7 +204,7 @@ public class BikeDetailsActivity extends SMBBaseActivity implements OnMapReadyCa
                             case BottomSheetBehaviorGoogleMapsLike.STATE_ANCHOR_POINT:
                                 // note; map resize in this case shold be performed only if the state change is due to a user bottom sheet interaction
                                 // when this happens programmatically, updatePadding should be triggered, but the map should not be re-centered
-                                // TODO: now it is i
+                                // TODO: now it is implemented using skipMove, we should find a better way to do this
                                 updatePadding();
                                 break;
                             case BottomSheetBehaviorGoogleMapsLike.STATE_HIDDEN:

--- a/app/src/main/java/it/geosolutions/savemybike/ui/adapters/ObservationAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/adapters/ObservationAdapter.java
@@ -30,6 +30,7 @@ public abstract class ObservationAdapter extends ArrayAdapter<Observation> {
     }
     static class ViewHolder {
         @BindView(R.id.observed_at) TextView observedAt;
+        @BindView(R.id.observation_address) TextView observedAddress;
         public ViewHolder(View view) {
             ButterKnife.bind(this, view);
         }
@@ -57,6 +58,7 @@ public abstract class ObservationAdapter extends ArrayAdapter<Observation> {
         Observation o = getItem(position);
         if(o != null) {
             holder.observedAt.setText(o.observedAt);
+            holder.observedAddress.setText(o.address);
         }
         if(isSelected(o)) {
             view.setBackgroundColor(getContext().getResources().getColor(R.color.colorAccent));

--- a/app/src/main/java/it/geosolutions/savemybike/ui/adapters/ObservationAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/adapters/ObservationAdapter.java
@@ -1,0 +1,73 @@
+package it.geosolutions.savemybike.ui.adapters;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.constraint.ConstraintLayout;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+
+import java.util.ArrayList;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import it.geosolutions.savemybike.R;
+import it.geosolutions.savemybike.model.Observation;
+
+public abstract class ObservationAdapter extends ArrayAdapter<Observation> {
+
+    private int resource;
+    public ObservationAdapter(@NonNull Context context, int viewId,
+                              ArrayList<Observation> objects) {
+        super(context, viewId, objects);
+        resource = viewId;
+    }
+    static class ViewHolder {
+        @BindView(R.id.observed_at) TextView observedAt;
+        public ViewHolder(View view) {
+            ButterKnife.bind(this, view);
+        }
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        ObservationAdapter.ViewHolder holder;
+        ViewGroup view;
+        if (convertView != null) {
+            holder = (ObservationAdapter.ViewHolder) convertView.getTag();
+        } else {
+            LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            convertView = inflater.inflate(resource, parent, false);
+            holder = new ObservationAdapter.ViewHolder(convertView);
+            convertView.setTag(holder);
+        }
+        if(convertView == null){
+            view = new ConstraintLayout(getContext());
+            LayoutInflater li = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            li.inflate(resource, view,true);
+        }else{
+            view = (ConstraintLayout) convertView;
+        }
+        Observation o = getItem(position);
+        if(o != null) {
+            holder.observedAt.setText(o.observedAt);
+        }
+        if(isSelected(o)) {
+            view.setBackgroundColor(getContext().getResources().getColor(R.color.colorAccent));
+        } else {
+            view.setBackgroundColor(getContext().getResources().getColor(android.R.color.transparent));
+        }
+        String dateFormatted = DateTimeFormat.forPattern("dd MMM, 'ore' HH:mm").print(new DateTime((o.observedAt)));
+        holder.observedAt.setText(dateFormatted);
+
+        return convertView;
+    }
+
+    public abstract boolean isSelected(Observation o);
+}

--- a/app/src/main/java/it/geosolutions/savemybike/ui/adapters/PopupAdapter.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/adapters/PopupAdapter.java
@@ -1,0 +1,39 @@
+
+package it.geosolutions.savemybike.ui.adapters;
+
+import android.annotation.SuppressLint;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+
+import com.google.android.gms.maps.GoogleMap.InfoWindowAdapter;
+import com.google.android.gms.maps.model.Marker;
+
+import it.geosolutions.savemybike.R;
+
+/**
+ * Adapter for map popup to allow multiline text
+ */
+public class PopupAdapter implements InfoWindowAdapter {
+    private View popup = null;
+    private LayoutInflater inflater = null;
+
+    public PopupAdapter(LayoutInflater inflater) {
+        this.inflater = inflater;
+    }
+
+    @Override
+    public View getInfoWindow(Marker marker) {
+       return null;
+    }
+
+    @Override
+    public View getInfoContents(Marker marker) {
+        View v = inflater.inflate(R.layout.popup, null);
+        TextView title = (TextView) v.findViewById(R.id.popup_title);
+        TextView subtitle = (TextView) v.findViewById(R.id.popup_snipplet);
+        title.setText(marker.getTitle());
+        subtitle.setText(marker.getSnippet());
+        return v;
+    }
+}

--- a/app/src/main/java/it/geosolutions/savemybike/ui/custom/BottomSheetBehaviorGoogleMapsLike.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/custom/BottomSheetBehaviorGoogleMapsLike.java
@@ -650,7 +650,7 @@ public class BottomSheetBehaviorGoogleMapsLike<V extends View> extends Coordinat
         mState = state;
         View bottomSheet = mViewRef.get();
         if (bottomSheet != null && mCallback != null) {
-//            mCallback.onStateChanged(bottomSheet, state);
+            bottomSheet.requestLayout();
             notifyStateChangedToListeners(bottomSheet, state);
         }
     }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/custom/BottomSheetBehaviorGoogleMapsLike.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/custom/BottomSheetBehaviorGoogleMapsLike.java
@@ -1,0 +1,888 @@
+package it.geosolutions.savemybike.ui.custom;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.v4.view.NestedScrollingChild;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.widget.ViewDragHelper;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.ref.WeakReference;
+import java.util.Vector;
+
+import it.geosolutions.savemybike.R;
+
+
+public class BottomSheetBehaviorGoogleMapsLike<V extends View> extends CoordinatorLayout.Behavior<V> {
+
+    /**
+     * Callback for monitoring events about bottom sheets.
+     */
+    public abstract static class BottomSheetCallback {
+
+        /**
+         * Called when the bottom sheet changes its state.
+         *
+         * @param bottomSheet The bottom sheet view.
+         * @param newState    The new state. This will be one of {@link #STATE_DRAGGING},
+         *                    {@link #STATE_SETTLING}, {@link #STATE_ANCHOR_POINT},
+         *                    {@link #STATE_EXPANDED},
+         *                    {@link #STATE_COLLAPSED}, or {@link #STATE_HIDDEN}.
+         */
+        public abstract void onStateChanged(@NonNull View bottomSheet, @State int newState);
+
+        /**
+         * Called when the bottom sheet is being dragged.
+         *
+         * @param bottomSheet The bottom sheet view.
+         * @param slideOffset The new offset of this bottom sheet within its range, from 0 to 1
+         *                    when it is moving upward, and from 0 to -1 when it moving downward.
+         */
+        public abstract void onSlide(@NonNull View bottomSheet, float slideOffset);
+    }
+
+    /**
+     * The bottom sheet is dragging.
+     */
+    public static final int STATE_DRAGGING = 1;
+
+    /**
+     * The bottom sheet is settling.
+     */
+    public static final int STATE_SETTLING = 2;
+
+    /**
+     * The bottom sheet is expanded_half_way.
+     */
+    public static final int STATE_ANCHOR_POINT = 3;
+
+    /**
+     * The bottom sheet is expanded.
+     */
+    public static final int STATE_EXPANDED = 4;
+
+    /**
+     * The bottom sheet is collapsed.
+     */
+    public static final int STATE_COLLAPSED = 5;
+
+    /**
+     * The bottom sheet is hidden.
+     */
+    public static final int STATE_HIDDEN = 6;
+
+    /** @hide */
+    @IntDef({STATE_EXPANDED, STATE_COLLAPSED, STATE_DRAGGING, STATE_ANCHOR_POINT, STATE_SETTLING, STATE_HIDDEN})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface State {}
+
+    private static final float HIDE_THRESHOLD = 0.5f;
+    private static final float HIDE_FRICTION = 0.1f;
+
+    private float mMinimumVelocity;
+
+    private int mPeekHeight;
+
+    private int mMinOffset;
+    private int mMaxOffset;
+
+    private static final int DEFAULT_ANCHOR_POINT = 700;
+    private int mAnchorPoint;
+
+    private boolean mHideable;
+
+    private boolean mCollapsible;
+
+    @State
+    private int mState = STATE_ANCHOR_POINT;
+    @State
+    private int mLastStableState = STATE_ANCHOR_POINT;
+
+    private ViewDragHelper mViewDragHelper;
+
+    private boolean mIgnoreEvents;
+
+    private boolean mNestedScrolled;
+
+    private int mParentHeight;
+
+    private WeakReference<V> mViewRef;
+
+    private WeakReference<View> mNestedScrollingChildRef;
+
+    private Vector<BottomSheetCallback> mCallback;
+
+    private int mActivePointerId;
+
+    private int mInitialY;
+
+    private boolean mTouchingScrollingChild;
+
+    /**
+     * Default constructor for instantiating BottomSheetBehaviors.
+     */
+    public BottomSheetBehaviorGoogleMapsLike() { }
+
+    /**
+     * Default constructor for inflating BottomSheetBehaviors from layout.
+     *
+     * @param context The {@link Context}.
+     * @param attrs   The {@link AttributeSet}.
+     */
+    public BottomSheetBehaviorGoogleMapsLike( Context context, AttributeSet attrs ) {
+        super( context, attrs );
+        TypedArray a = context.obtainStyledAttributes(attrs,
+                android.support.design.R.styleable.BottomSheetBehavior_Layout);
+        setPeekHeight(a.getDimensionPixelSize(
+                android.support.design.R.styleable.BottomSheetBehavior_Layout_behavior_peekHeight, 0));
+        setHideable(a.getBoolean(android.support.design.R.styleable.BottomSheetBehavior_Layout_behavior_hideable, false));
+        a.recycle();
+
+        /**
+         * Getting the anchorPoint...
+         */
+        mAnchorPoint = DEFAULT_ANCHOR_POINT;
+        mCollapsible = true;
+        a = context.obtainStyledAttributes(attrs, R.styleable.CustomBottomSheetBehavior);
+        if (attrs != null) {
+            mAnchorPoint = (int) a.getDimension( R.styleable.CustomBottomSheetBehavior_anchorPoint, 0);
+            mState = a.getInt(R.styleable.CustomBottomSheetBehavior_defaultState, STATE_ANCHOR_POINT);
+        }
+        a.recycle();
+
+        ViewConfiguration configuration = ViewConfiguration.get(context);
+        mMinimumVelocity = configuration.getScaledMinimumFlingVelocity();
+    }
+
+    @Override
+    public Parcelable onSaveInstanceState( CoordinatorLayout parent, V child ) {
+        return new SavedState(super.onSaveInstanceState(parent, child), mState);
+    }
+
+    @Override
+    public void onRestoreInstanceState( CoordinatorLayout parent, V child, Parcelable state ) {
+        SavedState ss = (SavedState) state;
+        super.onRestoreInstanceState(parent, child, ss.getSuperState());
+        // Intermediate states are restored as collapsed state
+        if (ss.state == STATE_DRAGGING || ss.state == STATE_SETTLING) {
+            mState = STATE_COLLAPSED;
+        } else {
+            mState = ss.state;
+        }
+
+        mLastStableState = mState;
+    }
+
+    @Override
+    public boolean onLayoutChild( CoordinatorLayout parent, V child, int layoutDirection ) {
+        // First let the parent lay it out
+        if (mState != STATE_DRAGGING && mState != STATE_SETTLING) {
+            if (parent.getFitsSystemWindows() &&
+                    !child.getFitsSystemWindows()) {
+                child.setFitsSystemWindows(true);
+            }
+            parent.onLayoutChild(child, layoutDirection);
+        }
+        // Offset the bottom sheet
+        mParentHeight = parent.getHeight();
+        mMinOffset = Math.max(0, mParentHeight - child.getHeight());
+        mMaxOffset = Math.max(mParentHeight - mPeekHeight, mMinOffset);
+
+        /**
+         * New behavior
+         */
+        if (mState == STATE_ANCHOR_POINT) {
+            ViewCompat.offsetTopAndBottom(child, mAnchorPoint);
+        } else if (mState == STATE_EXPANDED) {
+            ViewCompat.offsetTopAndBottom(child, mMinOffset);
+        } else if (mHideable && mState == STATE_HIDDEN) {
+            ViewCompat.offsetTopAndBottom(child, mParentHeight);
+        } else if (mState == STATE_COLLAPSED) {
+            ViewCompat.offsetTopAndBottom(child, mMaxOffset);
+        }
+        if ( mViewDragHelper == null ) {
+            mViewDragHelper = ViewDragHelper.create( parent, mDragCallback );
+        }
+        mViewRef = new WeakReference<>(child);
+        mNestedScrollingChildRef = new WeakReference<>( findScrollingChild( child ) );
+        return true;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent( CoordinatorLayout parent, V child, MotionEvent event ) {
+        if ( ! child.isShown() ) {
+            mIgnoreEvents = true;
+            return false;
+        }
+
+        int action = event.getActionMasked();
+        if ( action == MotionEvent.ACTION_DOWN ) {
+            reset();
+        }
+
+        switch ( action ) {
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                mTouchingScrollingChild = false;
+                mActivePointerId = MotionEvent.INVALID_POINTER_ID;
+                // Reset the ignore flag
+                if (mIgnoreEvents) {
+                    mIgnoreEvents = false;
+                    return false;
+                }
+                break;
+            case MotionEvent.ACTION_DOWN:
+                mScrollVelocityTracker.clear();
+                int initialX = (int) event.getX();
+                mInitialY = (int) event.getY();
+                if(mState == STATE_ANCHOR_POINT){
+                    mActivePointerId = event.getPointerId(event.getActionIndex());
+                    mTouchingScrollingChild = true;
+                }else {
+                    View scroll = mNestedScrollingChildRef.get();
+                    if (scroll != null && parent.isPointInChildBounds(scroll, initialX, mInitialY)) {
+                        mActivePointerId = event.getPointerId(event.getActionIndex());
+                        mTouchingScrollingChild = true;
+                    }
+                }
+                mIgnoreEvents = mActivePointerId == MotionEvent.INVALID_POINTER_ID &&
+                        !parent.isPointInChildBounds(child, initialX, mInitialY);
+                break;
+            case MotionEvent.ACTION_MOVE:
+                break;
+        }
+
+        if ( ! mIgnoreEvents  &&  mViewDragHelper.shouldInterceptTouchEvent( event ) ) {
+            return true;
+        }
+        // We have to handle cases that the ViewDragHelper does not capture the bottom sheet because
+        // it is not the top most view of its parent. This is not necessary when the touch event is
+        // happening over the scrolling content as nested scrolling logic handles that case.
+        View scroll = mNestedScrollingChildRef.get();
+        boolean ret = action == MotionEvent.ACTION_MOVE && scroll != null &&
+                !mIgnoreEvents && mState != STATE_DRAGGING &&
+                !parent.isPointInChildBounds(scroll, (int) event.getX(), (int) event.getY()) &&
+                Math.abs(mInitialY - event.getY()) > mViewDragHelper.getTouchSlop();
+        return ret;
+    }
+
+    @Override
+    public boolean onTouchEvent( CoordinatorLayout parent, V child, MotionEvent event ) {
+        if ( ! child.isShown() ) {
+            return false;
+        }
+
+        int action = event.getActionMasked();
+        if ( mState == STATE_DRAGGING  &&  action == MotionEvent.ACTION_DOWN ) {
+            return true;
+        }
+
+        // Detect scroll direction for ignoring collapsible
+        if(mLastStableState == STATE_ANCHOR_POINT && action==MotionEvent.ACTION_MOVE) {
+            if(event.getY()>mInitialY && !mCollapsible) {
+                reset();
+                return false;
+            }
+        }
+
+        if (mViewDragHelper == null) {
+            mViewDragHelper = ViewDragHelper.create(parent, mDragCallback);
+        }
+
+        mViewDragHelper.processTouchEvent(event);
+
+        if ( action == MotionEvent.ACTION_DOWN ) {
+            reset();
+        }
+
+        // The ViewDragHelper tries to capture only the top-most View. We have to explicitly tell it
+        // to capture the bottom sheet in case it is not captured and the touch slop is passed.
+        if ( action == MotionEvent.ACTION_MOVE  &&  ! mIgnoreEvents ) {
+            if ( Math.abs(mInitialY - event.getY()) > mViewDragHelper.getTouchSlop() ) {
+                mViewDragHelper.captureChildView( child, event.getPointerId(event.getActionIndex()) );
+            }
+        }
+        return ! mIgnoreEvents;
+    }
+
+    @Override
+    public boolean onStartNestedScroll( CoordinatorLayout coordinatorLayout, V child,
+                                        View directTargetChild, View target, int nestedScrollAxes,
+                                        @ViewCompat.NestedScrollType int type) {
+        mNestedScrolled = false;
+        return ( nestedScrollAxes & ViewCompat.SCROLL_AXIS_VERTICAL ) != 0;
+    }
+
+    private ScrollVelocityTracker mScrollVelocityTracker = new ScrollVelocityTracker();
+    private class ScrollVelocityTracker {
+        private long  mPreviousScrollTime = 0;
+        private float mScrollVelocity     = 0;
+
+        public void recordScroll( int dy ) {
+            long now = System.currentTimeMillis();
+
+            if ( mPreviousScrollTime != 0 ) {
+                long elapsed = now - mPreviousScrollTime;
+                mScrollVelocity = (float) dy / elapsed * 1000; // pixels per sec
+            }
+
+            mPreviousScrollTime = now;
+        }
+
+        public void clear() {
+            mPreviousScrollTime = 0;
+            mScrollVelocity = 0;
+        }
+
+        public float getScrollVelocity() {
+            return mScrollVelocity;
+        }
+    }
+
+    @Override
+    public void onNestedPreScroll( CoordinatorLayout coordinatorLayout, V child, View target,
+                                   int dx, int dy, int[] consumed,
+                                   @ViewCompat.NestedScrollType int type) {
+        View scrollingChild = mNestedScrollingChildRef.get();
+        if ( target != scrollingChild ) {
+            return;
+        }
+
+        mScrollVelocityTracker.recordScroll( dy );
+
+        int currentTop = child.getTop();
+        int newTop     = currentTop - dy;
+
+        // Force stop at the anchor - do not go from collapsed to expanded in one scroll
+        if (
+                ( mLastStableState == STATE_COLLAPSED  &&  newTop < mAnchorPoint )  ||
+                        ( mLastStableState == STATE_EXPANDED   &&  newTop > mAnchorPoint )
+                ) {
+            consumed[1] = dy;
+            ViewCompat.offsetTopAndBottom( child, mAnchorPoint - currentTop );
+            dispatchOnSlide( child.getTop() );
+            mNestedScrolled = true;
+            return;
+        }
+
+        if ( dy > 0 ) { // Upward
+            if ( newTop < mMinOffset ) {
+                consumed[1] = currentTop - mMinOffset;
+                ViewCompat.offsetTopAndBottom( child, -consumed[1] );
+                setStateInternal( STATE_EXPANDED );
+            } else {
+                consumed[1] = dy;
+                ViewCompat.offsetTopAndBottom( child, -dy );
+                setStateInternal( STATE_DRAGGING );
+            }
+        } else if (dy < 0) { // Downward
+            if (!ViewCompat.canScrollVertically(target, -1)) {
+                if (newTop <= mMaxOffset || mHideable) {
+                    // Restrict STATE_COLLAPSED if restrictedState is set
+                    if(mCollapsible==true || (mCollapsible==false && (mAnchorPoint - newTop)>=0)) {
+                        consumed[1] = dy;
+                        ViewCompat.offsetTopAndBottom(child, -dy);
+                        setStateInternal(STATE_DRAGGING);
+                    }
+                } else {
+                    consumed[1] = currentTop - mMaxOffset;
+                    ViewCompat.offsetTopAndBottom(child, -consumed[1]);
+                    setStateInternal(STATE_COLLAPSED);
+                }
+            }
+        }
+        dispatchOnSlide(child.getTop());
+        mNestedScrolled = true;
+    }
+
+    @Override
+    public void onStopNestedScroll( CoordinatorLayout coordinatorLayout, V child, View target,
+                                    @ViewCompat.NestedScrollType int type) {
+        if ( child.getTop() == mMinOffset ) {
+            setStateInternal( STATE_EXPANDED );
+            mLastStableState = STATE_EXPANDED;
+            return;
+        }
+        if ( target != mNestedScrollingChildRef.get()  ||  ! mNestedScrolled ) {
+            return;
+        }
+        int top;
+        int targetState;
+
+        // Are we flinging up?
+        float scrollVelocity = mScrollVelocityTracker.getScrollVelocity();
+        if ( scrollVelocity > mMinimumVelocity) {
+            if ( mLastStableState == STATE_COLLAPSED ) {
+                // Fling from collapsed to anchor
+                top = mAnchorPoint;
+                targetState = STATE_ANCHOR_POINT;
+            }
+            else
+            if ( mLastStableState == STATE_ANCHOR_POINT ) {
+                // Fling from anchor to expanded
+                top = mMinOffset;
+                targetState = STATE_EXPANDED;
+            }
+            else {
+                // We are already expanded
+                top = mMinOffset;
+                targetState = STATE_EXPANDED;
+            }
+        }
+        else
+            // Are we flinging down?
+            if ( scrollVelocity < -mMinimumVelocity ) {
+                if ( mLastStableState == STATE_EXPANDED ) {
+                    // Fling to from expanded to anchor
+                    top = mAnchorPoint;
+                    targetState = STATE_ANCHOR_POINT;
+                }
+                else if(mCollapsible==true) {
+                    if (mLastStableState == STATE_ANCHOR_POINT) {
+                        // Fling from anchor to collapsed
+                        top = mMaxOffset;
+                        targetState = STATE_COLLAPSED;
+                    } else {
+                        // We are already collapsed
+                        top = mMaxOffset;
+                        targetState = STATE_COLLAPSED;
+                    }
+                } else {
+                    top = mAnchorPoint;
+                    targetState = STATE_ANCHOR_POINT;
+                }
+            }
+            // Not flinging, just settle to the nearest state
+            else {
+                // Collapse?
+                int currentTop = child.getTop();
+                if ( currentTop > mAnchorPoint * 1.25 && mCollapsible==true) { // Multiply by 1.25 to account for parallax. The currentTop needs to be pulled down 50% of the anchor point before collapsing.
+                    top = mMaxOffset;
+                    targetState = STATE_COLLAPSED;
+                }
+                // Expand?
+                else
+                if ( currentTop < mAnchorPoint * 0.5 ) {
+                    top = mMinOffset;
+                    targetState = STATE_EXPANDED;
+                }
+                // Snap back to the anchor
+                else {
+                    top = mAnchorPoint;
+                    targetState = STATE_ANCHOR_POINT;
+                }
+            }
+
+        mLastStableState = targetState;
+        if ( mViewDragHelper.smoothSlideViewTo( child, child.getLeft(), top ) ) {
+            setStateInternal( STATE_SETTLING );
+            ViewCompat.postOnAnimation( child, new SettleRunnable( child, targetState ) );
+        } else {
+            setStateInternal( targetState );
+        }
+        mNestedScrolled = false;
+    }
+
+    @Override
+    public boolean onNestedPreFling(CoordinatorLayout coordinatorLayout, V child, View target,
+                                    float velocityX, float velocityY) {
+        return target == mNestedScrollingChildRef.get() &&
+                (mState != STATE_EXPANDED ||
+                        super.onNestedPreFling(coordinatorLayout, child, target,
+                                velocityX, velocityY));
+    }
+
+    /**
+     * Sets the height of the bottom sheet when it is collapsed.
+     *
+     * @param peekHeight The height of the collapsed bottom sheet in pixels.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_peekHeight
+     */
+    public final void setPeekHeight(int peekHeight) {
+        mPeekHeight = Math.max(0, peekHeight);
+        mMaxOffset = mParentHeight - peekHeight;
+    }
+
+    /**
+     * Gets the height of the bottom sheet when it is collapsed.
+     *
+     * @return The height of the collapsed bottom sheet.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_peekHeight
+     */
+    public final int getPeekHeight() {
+        return mPeekHeight;
+    }
+
+    public void setAnchorPoint(int anchorPoint) {
+        mAnchorPoint = anchorPoint;
+    }
+    public int getAnchorPoint(){
+        return mAnchorPoint;
+    }
+
+    /**
+     * Sets whether this bottom sheet can hide when it is swiped down.
+     *
+     * @param hideable {@code true} to make this bottom sheet hideable.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_hideable
+     */
+    public void setHideable(boolean hideable) {
+        mHideable = hideable;
+    }
+
+    /**
+     * Gets whether this bottom sheet can hide when it is swiped down.
+     *
+     * @return {@code true} if this bottom sheet can hide.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_hideable
+     */
+    public boolean isHideable() {
+        return mHideable;
+    }
+
+    /**
+     * Sets whether some states should be skipped.
+     *
+     * @param collapsible {@code true} to make this bottom sheet hideable.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_hideable
+     */
+    public void setCollapsible(boolean collapsible) {
+        mCollapsible = collapsible;
+    }
+
+    /**
+     * Gets whether some states should be skipped.
+     *
+     * @return {@code true} if this bottom sheet can hide.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_hideable
+     */
+    public boolean isCollapsible() {
+        return mCollapsible;
+    }
+
+    /**
+     * Adds a callback to be notified of bottom sheet events.
+     *
+     * @param callback The callback to notify when bottom sheet events occur.
+     */
+    public void addBottomSheetCallback(BottomSheetCallback callback) {
+        if (mCallback == null)
+            mCallback = new Vector<>();
+
+        mCallback.add(callback);
+    }
+
+    /**
+     * Sets the state of the bottom sheet. The bottom sheet will transition to that state with
+     * animation.
+     *
+     * @param state One of {@link #STATE_COLLAPSED}, {@link #STATE_ANCHOR_POINT},
+     *              {@link #STATE_EXPANDED} or {@link #STATE_HIDDEN}.
+     */
+    public final void setState( @State int state ) {
+        if ( state == mState ) {
+            return;
+        }
+
+        /**
+         * New behavior (added: state == STATE_ANCHOR_POINT ||)
+         */
+        if ( state == STATE_COLLAPSED || state == STATE_EXPANDED || state == STATE_ANCHOR_POINT ||
+                (mHideable && state == STATE_HIDDEN)) {
+            mState = state;
+            mLastStableState = state;
+        }
+
+        V child = mViewRef == null ? null : mViewRef.get();
+        if (child == null) {
+            return;
+        }
+        int top;
+        if (state == STATE_COLLAPSED) {
+            top = mMaxOffset;
+        }
+        else
+        if (state == STATE_ANCHOR_POINT) {
+            top = mAnchorPoint;
+        }
+        else
+        if (state == STATE_EXPANDED) {
+            top = mMinOffset;
+        }
+        else
+        if (mHideable && state == STATE_HIDDEN) {
+            top = mParentHeight;
+        } else {
+            throw new IllegalArgumentException("Illegal state argument: " + state);
+        }
+        setStateInternal(STATE_SETTLING);
+        if (mViewDragHelper.smoothSlideViewTo(child, child.getLeft(), top)) {
+            ViewCompat.postOnAnimation(child, new SettleRunnable(child, state));
+        }
+    }
+
+    /**
+     * Gets the current state of the bottom sheet.
+     *
+     * @return One of {@link #STATE_EXPANDED}, {@link #STATE_ANCHOR_POINT}, {@link #STATE_COLLAPSED},
+     * {@link #STATE_DRAGGING}, and {@link #STATE_SETTLING}.
+     */
+    @State
+    public final int getState() {
+        return mState;
+    }
+
+    private void setStateInternal(@State int state) {
+        if (mState == state) {
+            return;
+        }
+        mState = state;
+        View bottomSheet = mViewRef.get();
+        if (bottomSheet != null && mCallback != null) {
+//            mCallback.onStateChanged(bottomSheet, state);
+            notifyStateChangedToListeners(bottomSheet, state);
+        }
+    }
+
+    private void notifyStateChangedToListeners(@NonNull View bottomSheet, @State int newState) {
+        for (BottomSheetCallback bottomSheetCallback:mCallback) {
+            bottomSheetCallback.onStateChanged(bottomSheet, newState);
+        }
+    }
+
+    private void notifyOnSlideToListeners(@NonNull View bottomSheet, float slideOffset) {
+        for (BottomSheetCallback bottomSheetCallback:mCallback) {
+            bottomSheetCallback.onSlide(bottomSheet, slideOffset);
+        }
+    }
+
+    private void reset() {
+        mActivePointerId = ViewDragHelper.INVALID_POINTER;
+    }
+
+    private boolean shouldHide(View child, float yvel) {
+        if (child.getTop() < mMaxOffset) {
+            // It should not hide, but collapse.
+            return false;
+        }
+        final float newTop = child.getTop() + yvel * HIDE_FRICTION;
+        return Math.abs(newTop - mMaxOffset) / (float) mPeekHeight > HIDE_THRESHOLD;
+    }
+
+    private View findScrollingChild(View view) {
+        if (view instanceof NestedScrollingChild) {
+            return view;
+        }
+        if (view instanceof ViewGroup) {
+            ViewGroup group = (ViewGroup) view;
+            for (int i = 0, count = group.getChildCount(); i < count; i++) {
+                View scrollingChild = findScrollingChild(group.getChildAt(i));
+                if (scrollingChild != null) {
+                    return scrollingChild;
+                }
+            }
+        }
+        return null;
+    }
+
+    private final ViewDragHelper.Callback mDragCallback = new ViewDragHelper.Callback() {
+
+        @Override
+        public boolean tryCaptureView( View child, int pointerId ) {
+            if ( mState == STATE_DRAGGING ) {
+                return false;
+            }
+            if ( mTouchingScrollingChild ) {
+                return false;
+            }
+            if ( mState == STATE_EXPANDED  &&  mActivePointerId == pointerId ) {
+                View scroll = mNestedScrollingChildRef.get();
+                if (scroll != null && scroll.canScrollVertically(-1)) {
+                    // Let the content scroll up
+                    return false;
+                }
+            }
+            return mViewRef != null && mViewRef.get() == child;
+        }
+
+        @Override
+        public void onViewPositionChanged( View changedView, int left, int top, int dx, int dy ) {
+            dispatchOnSlide( top );
+        }
+
+        @Override
+        public void onViewDragStateChanged( int state ) {
+            if ( state == ViewDragHelper.STATE_DRAGGING ) {
+                setStateInternal( STATE_DRAGGING );
+            }
+        }
+
+        @Override
+        public void onViewReleased( View releasedChild, float xvel, float yvel ) {
+            int top;
+            @State int targetState;
+            if ( yvel < 0 ) { // Moving up
+                top = mMinOffset;
+                targetState = STATE_EXPANDED;
+            }
+            else
+            if ( mHideable  &&  shouldHide(releasedChild, yvel) ) {
+                top = mParentHeight;
+                targetState = STATE_HIDDEN;
+            }
+            else
+            if ( yvel == 0.f ) {
+                int currentTop = releasedChild.getTop();
+                if (Math.abs(currentTop - mMinOffset) < Math.abs(currentTop - mMaxOffset)) {
+                    top = mMinOffset;
+                    targetState = STATE_EXPANDED;
+                } else {
+                    top = mMaxOffset;
+                    targetState = STATE_COLLAPSED;
+                }
+            } else {
+                top = mMaxOffset;
+                targetState = STATE_COLLAPSED;
+            }
+
+            // Restrict Collapsed view (optional)
+            if(!mCollapsible && targetState==STATE_COLLAPSED) {
+                top = mAnchorPoint;
+                targetState = STATE_ANCHOR_POINT;
+            }
+
+            if ( mViewDragHelper.settleCapturedViewAt(releasedChild.getLeft(), top) ) {
+                setStateInternal(STATE_SETTLING);
+                ViewCompat.postOnAnimation(releasedChild,
+                        new SettleRunnable(releasedChild, targetState));
+            } else {
+                setStateInternal(targetState);
+            }
+        }
+
+        @Override
+        public int clampViewPositionVertical(View child, int top, int dy) {
+            return constrain(top, mMinOffset, mHideable ? mParentHeight : mMaxOffset);
+        }
+        int constrain(int amount, int low, int high) {
+            return amount < low ? low : (amount > high ? high : amount);
+        }
+
+        @Override
+        public int clampViewPositionHorizontal(View child, int left, int dx) {
+            return child.getLeft();
+        }
+
+        @Override
+        public int getViewVerticalDragRange(View child) {
+            if (mHideable) {
+                return mParentHeight - mMinOffset;
+            } else {
+                return mMaxOffset - mMinOffset;
+            }
+        }
+    };
+
+    private void dispatchOnSlide( int top ) {
+        View bottomSheet = mViewRef.get();
+        if (bottomSheet != null && mCallback != null) {
+            if (top > mMaxOffset) {
+                notifyOnSlideToListeners(bottomSheet, (float) (mMaxOffset - top) / mPeekHeight);
+            } else {
+                notifyOnSlideToListeners(bottomSheet, (float) (mMaxOffset - top) / ((mMaxOffset - mMinOffset)));
+            }
+        }
+    }
+
+    private class SettleRunnable implements Runnable {
+
+        private final View mView;
+
+        @State
+        private final int mTargetState;
+
+        SettleRunnable( View view, @State int targetState ) {
+            mView = view;
+            mTargetState = targetState;
+        }
+
+        @Override
+        public void run() {
+            if ( mViewDragHelper != null  &&  mViewDragHelper.continueSettling( true ) ) {
+                ViewCompat.postOnAnimation( mView, this );
+            } else {
+                setStateInternal( mTargetState );
+            }
+        }
+    }
+
+    protected static class SavedState extends View.BaseSavedState {
+
+        @State
+        final int state;
+
+        public SavedState( Parcel source ) {
+            super( source );
+            // noinspection ResourceType
+            state = source.readInt();
+        }
+
+        public SavedState(Parcelable superState, @State int state) {
+            super(superState);
+            this.state = state;
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeInt(state);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+                    @Override
+                    public SavedState createFromParcel(Parcel source) {
+                        return new SavedState(source);
+                    }
+
+                    @Override
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
+    }
+
+    /**
+     * A utility function to get the {@link BottomSheetBehaviorGoogleMapsLike} associated with the {@code view}.
+     *
+     * @param view The {@link View} with {@link BottomSheetBehaviorGoogleMapsLike}.
+     * @param <V> Instance of behavior
+     * @return The {@link BottomSheetBehaviorGoogleMapsLike} associated with the {@code view}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <V extends View> BottomSheetBehaviorGoogleMapsLike<V> from(V view) {
+        ViewGroup.LayoutParams params = view.getLayoutParams();
+        if (!(params instanceof CoordinatorLayout.LayoutParams)) {
+            throw new IllegalArgumentException("The view is not a child of CoordinatorLayout");
+        }
+        CoordinatorLayout.Behavior behavior = ((CoordinatorLayout.LayoutParams) params)
+                .getBehavior();
+        if (!(behavior instanceof BottomSheetBehaviorGoogleMapsLike)) {
+            throw new IllegalArgumentException(
+                    "The view is not associated with BottomSheetBehaviorGoogleMapsLike");
+        }
+        return (BottomSheetBehaviorGoogleMapsLike<V>) behavior;
+    }
+
+}

--- a/app/src/main/java/it/geosolutions/savemybike/ui/custom/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/custom/CustomBottomSheetBehavior.java
@@ -1,0 +1,56 @@
+package it.geosolutions.savemybike.ui.custom;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.design.widget.BottomSheetBehavior;
+import android.support.design.widget.CoordinatorLayout;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+
+public class CustomBottomSheetBehavior<V extends View> extends BottomSheetBehavior<V> {
+
+    private boolean isExpandedOrCollapsed;
+
+    public CustomBottomSheetBehavior() {
+        super();
+
+        listenForSlideEvents();
+    }
+
+    public CustomBottomSheetBehavior(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        listenForSlideEvents();
+    }
+
+    void listenForSlideEvents() {
+        setBottomSheetCallback(new BottomSheetCallback() {
+            @Override
+            public void onStateChanged(@NonNull View bottomSheet, int newState) {
+            }
+
+            @Override
+            public void onSlide(@NonNull View bottomSheet, float slideOffset) {
+                isExpandedOrCollapsed = slideOffset < 0.3f || slideOffset > 0.6f;
+            }
+        });
+    }
+
+    @Override
+    public boolean onTouchEvent(CoordinatorLayout parent, V child, MotionEvent event) {
+
+        if (!isExpandedOrCollapsed) {
+            int action = event.getActionMasked();
+            switch (action) {
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    return true; // allow click anyway
+                case MotionEvent.ACTION_DOWN:
+                    return isExpandedOrCollapsed; // WIP
+            }
+        }
+
+        return super.onTouchEvent(parent, child, event); // TODO: capture events to allow click
+    }
+}

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/BikeDetailsFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/BikeDetailsFragment.java
@@ -1,0 +1,170 @@
+package it.geosolutions.savemybike.ui.fragment;
+
+import android.content.Context;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.ShapeDrawable;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import it.geosolutions.savemybike.R;
+import it.geosolutions.savemybike.data.server.RetrofitClient;
+import it.geosolutions.savemybike.data.server.SMBRemoteServices;
+import it.geosolutions.savemybike.model.Bike;
+import it.geosolutions.savemybike.model.Cost;
+import it.geosolutions.savemybike.model.EmissionData;
+import it.geosolutions.savemybike.model.HealthData;
+import it.geosolutions.savemybike.model.Observation;
+import it.geosolutions.savemybike.model.Track;
+import it.geosolutions.savemybike.model.Vehicle;
+import it.geosolutions.savemybike.ui.VehicleUtils;
+import it.geosolutions.savemybike.ui.activity.BikeDetailsActivity;
+import it.geosolutions.savemybike.ui.activity.TrackDetailsActivity;
+import it.geosolutions.savemybike.ui.adapters.EmissionAdapter;
+import it.geosolutions.savemybike.ui.adapters.IconDataAdapter;
+import it.geosolutions.savemybike.ui.adapters.ObservationAdapter;
+import it.geosolutions.savemybike.ui.callback.OnFragmentInteractionListener;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * @author Lorenzo Natali, GeoSolutions S.a.s.
+ * TrackDetailsFragment Show track details in the releated fragment
+ *
+ */
+public class BikeDetailsFragment extends Fragment {
+
+    private OnFragmentInteractionListener mListener;
+    @BindView(R.id.observation_list) ListView observationList;
+    ArrayList<Observation> observations = new ArrayList<>();
+    ObservationAdapter observationAdapter;
+    Bike bike;
+    public EventCallbacks callbacks;
+    private Observation selectedItem;
+
+    public void setSelected(String selected) {
+        for(int i = 0; i < observations.size(); i++) {
+            Observation o = observations.get(i);
+            if(o.id != null && o.id.equals(selected)) {
+                selectedItem = o;
+                observationList.setItemChecked(i, true);
+                observationAdapter.notifyDataSetChanged();
+            }
+        }
+
+    }
+
+    public interface EventCallbacks {
+        public void onSelect(Observation o);
+    };
+
+    public BikeDetailsFragment() {
+        // Required empty public constructor
+    }
+
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+         observationAdapter = new ObservationAdapter(getContext(), R.layout.item_observation, observations) {
+             public boolean isSelected(Observation o) {return o == selectedItem;}
+         };
+    }
+
+    public void setEventsCallbacks(EventCallbacks callbacks) {
+        this.callbacks = callbacks;
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View view = inflater.inflate(R.layout.fragment_bike_details, container, false);
+        ButterKnife.bind(this, view);
+        bike = (Bike) getActivity().getIntent().getExtras().get(BikeDetailsActivity.BIKE);
+        observationList.setAdapter(observationAdapter);
+        observationList.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
+        observationList.setOnItemClickListener(((parent, view1, position, id) -> {
+            selectedItem = (Observation) parent.getItemAtPosition(position);
+            if(callbacks != null) {
+                callbacks.onSelect((Observation) parent.getItemAtPosition(position));
+            }
+        }));
+        observationAdapter.clear();
+        observationAdapter.addAll(observations);
+        observationAdapter.notifyDataSetChanged();
+        return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+    }
+
+
+    public void setLoading(boolean loading) {
+        if(getActivity() != null) {
+            View v = getActivity().findViewById(R.id.loading_container);
+            if(v != null) {
+                v.setVisibility(loading ? View.VISIBLE : View.GONE);
+            }
+        }
+    }
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mListener = null;
+    }
+
+    public void updateListData(JSONObject geojson) {
+
+        try{
+        JSONArray jArray = geojson.getJSONArray("features");
+
+        observations.clear();
+        if (jArray != null) {
+            for (int i=0;i<jArray.length();i++){
+
+                observations.add(new Observation(jArray.getJSONObject(i)));
+            }
+        }
+        } catch (JSONException e) {
+            Log.e("BikeDetailsFragment", "can not cast observations");
+        }
+        if(observationAdapter != null) {
+            observationAdapter.notifyDataSetChanged();
+        }
+
+
+    }
+}
+

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/BikeListFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/BikeListFragment.java
@@ -1,30 +1,25 @@
 package it.geosolutions.savemybike.ui.fragment;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.annotation.MainThread;
-import android.support.v4.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import it.geosolutions.savemybike.BuildConfig;
-import it.geosolutions.savemybike.Configuration;
 import it.geosolutions.savemybike.R;
 import it.geosolutions.savemybike.data.Constants;
 import it.geosolutions.savemybike.data.server.RetrofitClient;
@@ -33,6 +28,7 @@ import it.geosolutions.savemybike.model.Bike;
 import it.geosolutions.savemybike.model.CurrentStatus;
 import it.geosolutions.savemybike.model.PaginatedResult;
 import it.geosolutions.savemybike.ui.BikeAdapter;
+import it.geosolutions.savemybike.ui.activity.BikeDetailsActivity;
 import it.geosolutions.savemybike.ui.activity.SaveMyBikeActivity;
 import it.geosolutions.savemybike.ui.tasks.GetRemoteConfigTask;
 import retrofit2.Call;
@@ -65,9 +61,19 @@ public class BikeListFragment extends Fragment {
         bikes = activity.getConfiguration().getBikes(activity);
         bikeAdapter = new BikeAdapter(activity, R.layout.item_bike, activity.getConfiguration().getBikes(activity)) {
             @Override
+            protected void onItemClick(Bike bike) {
+                Intent intent = new Intent(getActivity(), BikeDetailsActivity.class);
+
+                intent.putExtra(BikeDetailsActivity.BIKE, bike);
+                getActivity().startActivity(intent);
+                getActivity().overridePendingTransition(R.anim.fadein, R.anim.fadeout);
+            }
+
+            @Override
             public void updateStatus(Bike bike, String details) {
                 updateBikeStatus(bike, details);
             }
+
         };
         refreshLayout.setOnRefreshListener(() -> getBikes());
         listView.setAdapter(bikeAdapter);

--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TrackDetailsFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/TrackDetailsFragment.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 
 import java.util.ArrayList;
 
+import butterknife.ButterKnife;
 import it.geosolutions.savemybike.R;
 import it.geosolutions.savemybike.data.server.RetrofitClient;
 import it.geosolutions.savemybike.data.server.SMBRemoteServices;
@@ -58,7 +59,6 @@ public class TrackDetailsFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_track_details, container, false);
-
         return view;
     }
 

--- a/app/src/main/res/drawable/ic_expand_down.xml
+++ b/app/src/main/res/drawable/ic_expand_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_expand_up.xml
+++ b/app/src/main/res/drawable/ic_expand_up.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,8l-6,6 1.41,1.41L12,10.83l4.59,4.58L18,14z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_place.xml
+++ b/app/src/main/res/drawable/ic_place.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/select_list_item_backround.xml
+++ b/app/src/main/res/drawable/select_list_item_backround.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true" android:drawable="@color/colorAccent" />
+    <item android:state_checked="true" android:drawable="@color/colorAccent" />
+    <item android:drawable="@android:color/transparent" />
+</selector>

--- a/app/src/main/res/layout/bike_details.xml
+++ b/app/src/main/res/layout/bike_details.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Full view with Map, Toolbar and BottomSheet
+-->
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/bikes_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        android:background="@android:color/transparent"
+        app:elevation="0dp"
+        >
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/bike_details_toolbar"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_collapseMode="parallax"
+            android:minHeight="?attr/actionBarSize"
+            android:layout_width="match_parent"
+            android:background="@drawable/background_toolbar_translucent"
+            app:theme="@style/MapToolbar"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+        </android.support.v7.widget.Toolbar>
+    </android.support.design.widget.AppBarLayout>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <fragment
+            android:id="@+id/map"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context=".ui.activity.BikeDetailsActivity" />
+        <include layout="@layout/loading_container" android:id="@+id/loading_container"/>
+        <include layout="@layout/empty_view" android:id="@+id/emptyView"/>
+    </FrameLayout>
+
+    <!-- Bottom sheet -->
+    <include android:id="@+id/bike_details_bottom_sheet" layout="@layout/bike_details_sheet"></include>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/bike_details.xml
+++ b/app/src/main/res/layout/bike_details.xml
@@ -42,7 +42,7 @@
             android:layout_height="match_parent"
             tools:context=".ui.activity.BikeDetailsActivity" />
         <include layout="@layout/loading_container" android:id="@+id/loading_container"/>
-        <include layout="@layout/empty_view" android:id="@+id/emptyView"/>
+        <include layout="@layout/empty_bike_details" android:id="@+id/emptyView"/>
     </FrameLayout>
 
     <!-- Bottom sheet -->

--- a/app/src/main/res/layout/bike_details_sheet.xml
+++ b/app/src/main/res/layout/bike_details_sheet.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- BottomSheet content
- Has the Session Record view as top bar and a tab panel
+ BottomSheet content for bike details
+ Contains the header and a view pager
  -->
 <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     app:layout_behavior="it.geosolutions.savemybike.ui.custom.BottomSheetBehaviorGoogleMapsLike"
-
     app:anchorPoint="@dimen/bottom_sheet_anchor_point"
-
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">

--- a/app/src/main/res/layout/bike_details_sheet.xml
+++ b/app/src/main/res/layout/bike_details_sheet.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ BottomSheet content
+ Has the Session Record view as top bar and a tab panel
+ -->
+<LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    app:layout_behavior="it.geosolutions.savemybike.ui.custom.BottomSheetBehaviorGoogleMapsLike"
+
+    app:anchorPoint="@dimen/bottom_sheet_anchor_point"
+
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:id="@+id/tap_action_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="50dp"
+        android:background="@android:color/white"
+        android:orientation="vertical">
+
+        <include
+            android:id="@+id/session_row"
+            layout="@layout/row_bike"
+             />
+
+    </LinearLayout>
+
+    <android.support.design.widget.TabLayout
+        android:id="@+id/bike_details_tabs"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        app:tabMode="fixed" />
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/bike_details_viewpager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        />
+
+</LinearLayout>

--- a/app/src/main/res/layout/bike_details_sheet.xml
+++ b/app/src/main/res/layout/bike_details_sheet.xml
@@ -19,7 +19,7 @@
         android:id="@+id/tap_action_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="50dp"
+        android:layout_marginTop="?attr/actionBarSize"
         android:background="@android:color/white"
         android:orientation="vertical">
 

--- a/app/src/main/res/layout/empty_bike_details.xml
+++ b/app/src/main/res/layout/empty_bike_details.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:visibility="gone"
+    >
+
+    <ImageView
+        android:id="@+id/empty_icon"
+        android:layout_width="88dp"
+        android:layout_height="83dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="88dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        android:alpha="0.4"
+        app:srcCompat="@drawable/ic_place" />
+
+    <TextView
+        android:id="@+id/empty_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/no_position_available"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/empty_icon" />
+
+    <TextView
+        android:id="@+id/empty_description"
+        android:layout_width="216dp"
+        android:layout_height="100dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="44dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/empty_text"
+        app:layout_constraintVertical_bias="0.0" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_bike_details.xml
+++ b/app/src/main/res/layout/fragment_bike_details.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.NestedScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        tools:context=".ui.fragment.TrackDetailsFragment"
+        >
+        <ListView
+            android:choiceMode="singleChoice"
+            android:id="@+id/observation_list"
+            android:background="@drawable/select_list_item_backround"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:nestedScrollingEnabled="true"
+            tools:listitem="@layout/item_observation"/>
+    </android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_observation.xml
+++ b/app/src/main/res/layout/item_observation.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/observed_at"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginTop="8dp"
+        android:text="TextView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/ic_clock"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/observed_at"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_access_time" />
+
+    <ImageView
+        android:id="@+id/ic_bike"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_directions_bike" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/item_observation.xml
+++ b/app/src/main/res/layout/item_observation.xml
@@ -40,5 +40,19 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_directions_bike" />
+        app:srcCompat="@drawable/ic_place" />
+
+    <TextView
+        android:id="@+id/observation_address"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/ic_clock"
+        app:layout_constraintStart_toEndOf="@+id/ic_bike"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Via Verdi" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/observation_window.xml
+++ b/app/src/main/res/layout/observation_window.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/popup.xml
+++ b/app/src/main/res/layout/popup.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:maxWidth="300dp"
+    android:minWidth="100dp"
+    android:maxHeight="200dp"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/popup_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="title" />
+
+    <TextView
+        android:id="@+id/popup_snipplet"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/popup_title"
+        tools:text="description" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/row_bike.xml
+++ b/app/src/main/res/layout/row_bike.xml
@@ -24,10 +24,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/bike_img"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Bike name" />
 

--- a/app/src/main/res/layout/row_bike.xml
+++ b/app/src/main/res/layout/row_bike.xml
@@ -57,4 +57,15 @@
         app:layout_constraintEnd_toStartOf="@+id/last_update_date"
         app:layout_constraintTop_toTopOf="@+id/last_update_date"
         android:visibility="gone"/>
+
+    <ImageView
+        android:id="@+id/button_expand"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:src="@drawable/ic_expand_up"
+        app:layout_constraintBottom_toBottomOf="@+id/bike_img"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/bike_img" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/row_bike.xml
+++ b/app/src/main/res/layout/row_bike.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/bike_img"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_directions_bike"
+        />
+
+    <TextView
+        android:id="@+id/bike_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/bike_img"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Bike name" />
+
+    <TextView
+        android:id="@+id/last_update_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginTop="8dp"
+        android:text="N/A"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"
+        tools:text="08:00:00" />
+
+    <TextView
+        android:id="@+id/last_update_caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:text="@string/last_update"
+        app:layout_constraintBottom_toBottomOf="@+id/last_update_date"
+        app:layout_constraintEnd_toStartOf="@+id/last_update_date"
+        app:layout_constraintTop_toTopOf="@+id/last_update_date"
+        android:visibility="gone"/>
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -308,7 +308,7 @@
     <string name="uploading_sessions_description">Le tue registrazioni stanno per essere prese in carico dal sistema. A breve le potrai vedere nella lista delle tracce. Assicurati di aggiornare la lista, trascinandola in basso col dito, per ricevere le nuove tracce elaborate</string>
     <string name="recording_sessions">Registrazione in corso</string>
     <string name="recording_sessions_description">Non è possibile visualizzare le tracce da inviare durante la registrazione. Riprovare a registrazione conclusa</string>
-    <string name="bike_details">Dettagli</string>
     <string name="last_update">Ultimo aggiornamento</string>
     <string name="last_observations">Ultimi rilevamenti</string>
+    <string name="no_position_available">Nessuna posizione rilevata</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -308,4 +308,7 @@
     <string name="uploading_sessions_description">Le tue registrazioni stanno per essere prese in carico dal sistema. A breve le potrai vedere nella lista delle tracce. Assicurati di aggiornare la lista, trascinandola in basso col dito, per ricevere le nuove tracce elaborate</string>
     <string name="recording_sessions">Registrazione in corso</string>
     <string name="recording_sessions_description">Non è possibile visualizzare le tracce da inviare durante la registrazione. Riprovare a registrazione conclusa</string>
+    <string name="bike_details">Dettagli</string>
+    <string name="last_update">Ultimo aggiornamento</string>
+    <string name="last_observations">Ultimi rilevamenti</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,4 +9,6 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
     <dimen name="prizes_image_size">82dp</dimen>
+    <dimen name="bottom_sheet_peek_height">80dp</dimen>
+    <dimen name="bottom_sheet_anchor_point">300dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,4 +343,7 @@
     <string name="uploading_sessions_description">Your tracks will be loaded into the system soon and you will see them in the tracks list. Make you sure to update the track list dragging down the list with the finger </string>
     <string name="recording_sessions">Recording...</string>
     <string name="recording_sessions_description">You can not see tracks to send during a recording session. Try again when the recording session is finished</string>
+    <string name="bike_details">Dettagli</string>
+    <string name="last_update">Ultimo aggiornamento</string>
+    <string name="last_observations">Ultimi rilevamenti</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,7 +343,7 @@
     <string name="uploading_sessions_description">Your tracks will be loaded into the system soon and you will see them in the tracks list. Make you sure to update the track list dragging down the list with the finger </string>
     <string name="recording_sessions">Recording...</string>
     <string name="recording_sessions_description">You can not see tracks to send during a recording session. Try again when the recording session is finished</string>
-    <string name="bike_details">Dettagli</string>
-    <string name="last_update">Ultimo aggiornamento</string>
-    <string name="last_observations">Ultimi rilevamenti</string>
+    <string name="last_update">Last Update</string>
+    <string name="last_observations">Last Observations</string>
+    <string name="no_position_available">No Observations</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,4 +25,14 @@
     <style name="TextAppearanceFinish" parent="android:TextAppearance.Holo.Medium">
         <item name="android:textColor">#fff</item>
     </style>
+
+    <declare-styleable name="CustomBottomSheetBehavior">
+        <attr name="anchorPoint" format="dimension"/>
+        <attr name="defaultState" format="enum">
+            <enum name="stateAnchorPoint" value="3" />
+            <enum name="stateExpanded" value="4"/>
+            <enum name="stateCollapsed" value="5"/>
+            <enum name="stateHidden" value="6"/>
+        </attr>
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
Bikes observation provides a view of latest bike observations.

 - The user can see the bike's details by clicking on the bike image. A map with latest observations of the selected bike will be opened.
 - The user can select observations from the map or from the list. The map will show the observation and the details about it
 - If no observation is available, the user will se an empty view

![bike_observations](https://user-images.githubusercontent.com/1279510/48125996-5f751500-e280-11e8-93d5-c639163e2331.gif)
![image](https://user-images.githubusercontent.com/1279510/48126297-0e195580-e281-11e8-9083-47af922a9f86.png)

