### PR TITLE
Fix #82. Schedule token refresh

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/data/Constants.java
+++ b/app/src/main/java/it/geosolutions/savemybike/data/Constants.java
@@ -66,6 +66,17 @@ public class Constants {
 
     public final static float KM_TO_MILES = 0.621371192f;
     public final static float METER_TO_FEET = 3.2808399f;
+
+    /**
+     * Time before the token expiring when we should refresh the token
+     *
+     */
+    public static long TOKEN_REFRESH_BUFFER = 1000 * 60 * 60 * 24 * 3; // 3 days before expiring, force refresh on next startup or during the periodical check
+    /**
+     * Interval between checks to refresh the token
+     */
+    public static final long REFRESH_TOKEN_INTERVAL = 1000 * 60 * 60 * 24 * 1; // every day check for refresh
+
     public static final class Channels {
         public static final String TRACKS_VALID_ID = "it.geosolutions.savemybike.tracks_channel_valid";
         public static final String TRACKS_VALID_NAME = "Tracks validation success";

--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/LoginActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/LoginActivity.java
@@ -250,20 +250,21 @@ public final class LoginActivity extends AppCompatActivity {
             Long expiresAt = state.getAccessTokenExpirationTime();
             if (expiresAt == null) {
                 accessTokenInfoView.setText(R.string.no_access_token_expiry);
+                Log.w(TAG, "refresh impossible. This access token has no expire");
+                // Note: here we can not use TOKEN_REFRESH_BUFFER because if the next expireAt < currentTimeMillis - TOKEN_REFRESH_BUFFER
+                // the login goes in infinite loop (this condition is checked again and again after every refresh)
             } else if (expiresAt < System.currentTimeMillis()) {
+                Log.i(TAG, "refreshing token that expired at" + new Date(expiresAt).toString());
                 accessTokenInfoView.setText(R.string.access_token_expired);
                 refreshAccessToken();
                 return;
             } else {
-
-
+                Log.i(TAG, "the current token will expire at" + new Date(expiresAt).toString());
                 String template = getResources().getString(R.string.access_token_expires_at);
                 accessTokenInfoView.setText(String.format(template,
                         DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss ZZ").print(expiresAt)));
                 User localUser = it.geosolutions.savemybike.model.Configuration.getUserProfile(this);
-                if(localUser != null) {
 
-                }
                 if(localUser == null // first login
                     || localUser.getAcceptedTermsOfService() == null // old users that didn't have the profile autocomplete but did login
                     || localUser.getAcceptedTermsOfService() == false // terms of service unchecked.

--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/SaveMyBikeActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/SaveMyBikeActivity.java
@@ -41,16 +41,21 @@ import com.bumptech.glide.request.RequestOptions;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.openid.appauth.AppAuthConfiguration;
+import net.openid.appauth.AuthState;
 import net.openid.appauth.AuthorizationService;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import it.geosolutions.savemybike.AuthStateManager;
 import it.geosolutions.savemybike.BuildConfig;
 import it.geosolutions.savemybike.GlideApp;
 import it.geosolutions.savemybike.R;
@@ -195,6 +200,7 @@ public class SaveMyBikeActivity extends SMBBaseActivity implements OnFragmentInt
 
         }
         PowerManager.startPowerSaverIntent(this);
+        setupTokenAutoRefresh();
     }
 
     /**
@@ -1128,4 +1134,57 @@ public class SaveMyBikeActivity extends SMBBaseActivity implements OnFragmentInt
         }).execute();
     }
 
+    // Autorefresh of token
+    boolean tokenRefreshTimerScheduled = false;
+
+    /**
+     * If the activity stay up for a long time, the token may expire.
+     * This method schedules a task that periodically check the refresh token to see if it
+     * has to be refreshed.
+     * TODO: a better solution is to schedule to a precise time the refresh, instead of checking it every X period (REFRESH_TOKEN_INTERVAL is the current interval)
+     */
+    public void setupTokenAutoRefresh() {
+        Context context = this;
+        if(!tokenRefreshTimerScheduled) {
+            Timer timer = new Timer();
+            TimerTask t = new TimerTask() {
+                @Override
+                public void run() {
+                    Log.i(TAG, "running token refresh");
+                    AuthState state = AuthStateManager.getInstance(context).getCurrent();
+                    Long expiresAt = state.getAccessTokenExpirationTime();
+                    if (expiresAt == null) {
+                        Log.w(TAG, "token refresh impossible. This access token has no expire");
+
+                    } else if (expiresAt < System.currentTimeMillis() + Constants.TOKEN_REFRESH_BUFFER) {
+                        Log.i(TAG, "running token refresh that is going to expire at " + new Date(expiresAt).toString());
+                        AuthStateManager authStateManager = AuthStateManager.getInstance(context);
+                        authStateManager.getCurrent().createTokenRefreshRequest();
+                        it.geosolutions.savemybike.Configuration mConfiguration = it.geosolutions.savemybike.Configuration.getInstance(context);
+                        AuthorizationService authService = new AuthorizationService(
+                                context,
+                                new AppAuthConfiguration.Builder()
+                                        .setConnectionBuilder(mConfiguration.getConnectionBuilder())
+                                        .build());
+                        // TODO : refresh
+                        try {
+                            authService.performTokenRequest(
+                                    authStateManager.getCurrent().createTokenRefreshRequest(),
+                                    authStateManager.getCurrent().getClientAuthentication(),
+                                    (tokenResponse, authException) -> {
+                                        Long newExpiringDate = tokenResponse.accessTokenExpirationTime;
+                                        Log.i(TAG, "running token successful. Next token will expire at " + new Date(newExpiringDate).toString());
+                                        authStateManager.updateAfterTokenResponse(tokenResponse, authException);
+                                    }
+                            );
+                        } catch (Exception e) {
+                            Log.e(TAG, "Error when refreshing access token", e);
+                        }
+                    }
+                }
+            };
+            timer.scheduleAtFixedRate(t, 0, Constants.REFRESH_TOKEN_INTERVAL);
+            tokenRefreshTimerScheduled = true;
+        }
+    }
 }

--- a/app/src/main/java/it/geosolutions/savemybike/ui/activity/SaveMyBikeActivity.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/activity/SaveMyBikeActivity.java
@@ -1172,8 +1172,14 @@ public class SaveMyBikeActivity extends SMBBaseActivity implements OnFragmentInt
                                     authStateManager.getCurrent().createTokenRefreshRequest(),
                                     authStateManager.getCurrent().getClientAuthentication(),
                                     (tokenResponse, authException) -> {
-                                        Long newExpiringDate = tokenResponse.accessTokenExpirationTime;
-                                        Log.i(TAG, "running token successful. Next token will expire at " + new Date(newExpiringDate).toString());
+                                        if(tokenResponse != null) {
+                                            Long newExpiringDate = tokenResponse.accessTokenExpirationTime;
+                                            Log.i(TAG, "running token successful. Next token will expire at " + new Date(newExpiringDate).toString());
+                                        } else {
+                                            Log.e(TAG, "Error when refreshing access token", authException);
+                                            // TODO: check if it is an authorization error.
+                                            // TODO: if network error, postpone the refresh
+                                        }
                                         authStateManager.updateAfterTokenResponse(tokenResponse, authException);
                                     }
                             );


### PR DESCRIPTION
This solution refresh the token before its expiration to avoid issues during usage due to token expiration. 

The refresh check is applied during the login, if the token is already expired.

When the main activity startup (`SaveMyBikeActivity`) the application check if the token is next to expire. Then, during application life in background (that is also SaveMyBikeActivity life), A check is repeated every 1 day (REFRESH_TOKEN_INTERVAL) .
The Activity checks if current time has passed `tokenExpirationTime - TOKEN_REFRESH_BUFFER`, so if the token have to be refreshed. 

Application's open from notification pass anyway through login activity and so a refresh will be performed again if the session is expired in the meanwhile.

Note, the TOKEN_REFRESH_BUFFER is not used on login because we may need to assume that TOKEN_REFRESH_BUFFER < server side configured expire time. 

Constants: 
 - TOKEN_REFRESH_BUFFER: 3 days
 - REFRESH_TOKEN_INTERVAL: 1 day

