### PR TITLE
Fix #92 and Fix #93. Improvement to recording view

### DIFF
--- a/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
+++ b/app/src/main/java/it/geosolutions/savemybike/ui/fragment/RecordFragment.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.List;
 import java.util.Locale;
@@ -134,6 +135,8 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
             case STOPPED:
                 //switch to "Record" UI
                 recordButton.setImageDrawable(ContextCompat.getDrawable(getActivity(), R.drawable.ic_record_play_pause));
+                distTV.setText("");
+                timeTV.setText("");
                 break;
         }
     }
@@ -188,19 +191,25 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
             }
 
             final double dist = session.getDistance();
-            final long time = session.getOverallTime();
-            Log.i(TAG, "DIST: "+ dist+ " TIME: "+time);
+            final long startingTime = session.getStartingTime();
+            final long nowTime = System.currentTimeMillis();
 
-            if(((SaveMyBikeActivity)getActivity()).getConfiguration().metric){
+            Log.i(TAG, "DIST: "+ dist+ " TIME: "+ (nowTime - startingTime));
+
+            if( getActivity() != null && ((SaveMyBikeActivity)getActivity()).getConfiguration().metric){
 
                 distTV.setText(String.format(Locale.US,"%.2f %s", dist / 1000f, Constants.UNIT_KM));
             }else{
                 distTV.setText(String.format(Locale.US,"%.2f %s", dist / 1000f * Constants.KM_TO_MILES, Constants.UNIT_MI));
             }
-            timeTV.setText(Util.longToTimeString(time));
+            if(startingTime > 0) {
+                timeTV.setText(Util.longToTimeString( nowTime - startingTime ));
+            } else {
+                timeTV.setText(R.string.go);
+            }
+
 
         }
-
     }
 
     /**
@@ -267,7 +276,7 @@ public class RecordFragment extends Fragment implements RecordingEventListener {
         } else {
             if(mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
                 ((SaveMyBikeActivity)getActivity()).startRecording();
-
+                Toast.makeText(getContext(), R.string.timer_info_toast, Toast.LENGTH_LONG).show();
                 applySessionState(Session.SessionState.ACTIVE);
             } else {
                 showGPSDiabledDialog();

--- a/app/src/main/res/layout/fragment_record.xml
+++ b/app/src/main/res/layout/fragment_record.xml
@@ -155,7 +155,7 @@
     <TextView
         android:id="@+id/stats_time"
         android:layout_width="0dp"
-        android:layout_height="83dp"
+        android:layout_height="0dp"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="10dp"
         android:fontFamily="sans-serif"
@@ -163,7 +163,7 @@
         android:textAlignment="center"
         android:textColor="@android:color/white"
         android:textSize="24sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/record_button"
         app:layout_constraintEnd_toStartOf="@+id/record_button"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -312,4 +312,6 @@
     <string name="last_observations">Ultimi rilevamenti</string>
     <string name="no_position_available">Nessuna posizione rilevata</string>
     <string name="bike_observed_notification_observed">Una delle tue bici è stata rilevata dai sensori</string>
+    <string name="go">Vai!</string>
+    <string name="timer_info_toast">Il timer partirà al primo spostamento significativo rilevato</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -347,4 +347,6 @@
     <string name="last_observations">Last Observations</string>
     <string name="no_position_available">No Observations</string>
     <string name="bike_observed_notification_observed">One of your bikes has been observed by a sensor</string>
+    <string name="go">Go!</string>
+    <string name="timer_info_toast">The timer will start at the first significant displacement detected</string>
 </resources>


### PR DESCRIPTION
Implemented the following behaviour: 
 - Fix #92 On startup a message explains when the timer will start. This because the time in the timer is coming from effective recording points, and it is not possible get the current point as point of start in an easy way. 
 - Fix #93 On stop, the time and the distance are not shown anymore. 


![go](https://user-images.githubusercontent.com/1279510/49024957-e68c1d80-f19a-11e8-978a-e40d72f33abb.gif)
